### PR TITLE
test: Add pytest unit-test layer

### DIFF
--- a/crowsnet.py
+++ b/crowsnet.py
@@ -4,6 +4,7 @@
 import sys
 import click
 from utilities.container import build_container, run_container
+from utilities.testing import run_integration, run_pytest
 
 
 @click.group()
@@ -49,9 +50,12 @@ def update(limit):
 
 
 @cli.command()
-def test():
-    """Run tests."""
-    sys.exit(run_container("test"))
+@click.option("--integration", is_flag=True, help="Run the molecule integration suite against the stage VM")
+def test(integration):
+    """Run the test suite (pytest unit tests by default)."""
+    if integration:
+        sys.exit(run_integration())
+    sys.exit(run_pytest())
 
 
 @cli.command()

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -4,6 +4,7 @@ import pulumi
 from pulumi_proxmoxve import Provider
 
 from components import ProxmoxVM
+from vms import select_vms
 
 config = pulumi.Config("proxmox")
 endpoint = config.require("endpoint")
@@ -17,22 +18,7 @@ provider = Provider(
     insecure=True
 )
 
-STAGE_VMS = [
-    {"name": "lab",    "vmid": 200, "cpu": 2, "ram": 4096,  "ip": "192.168.4.200", "mac": "CA:9B:F1:85:90:C0", "clone": True, "template": "small"},
-]
-
-PROD_VMS = [
-    {"name": "gate",   "vmid": 100, "cpu": 2, "ram": 4096,  "ip": "192.168.4.100", "mac": "82:08:61:78:5A:6C", "clone": False, "template": "small"},
-    {"name": "proxy",  "vmid": 101, "cpu": 2, "ram": 8192,  "ip": "192.168.4.101", "mac": "BC:24:11:88:D8:67", "clone": False, "template": "small"},
-    {"name": "bailey", "vmid": 125, "cpu": 4, "ram": 12288, "ip": "192.168.4.125", "mac": "02:26:85:4A:AC:52", "clone": False, "template": "small"},
-    {"name": "kube-1", "vmid": 126, "cpu": 2, "ram": 8192,  "ip": "192.168.4.126", "mac": "BC:24:11:91:7B:19", "clone": False, "template": "large"},
-]
-
-stack = pulumi.get_stack()
-if stack not in ("stage", "prod"):
-    raise ValueError(f"Unknown stack '{stack}'. Expected 'stage' or 'prod'.")
-
-vms = STAGE_VMS if stack == "stage" else PROD_VMS
+vms = select_vms(pulumi.get_stack())
 
 for vm in vms:
     ProxmoxVM(

--- a/pulumi/vms.py
+++ b/pulumi/vms.py
@@ -1,0 +1,25 @@
+"""VM definitions and stack selection for CrowsNet infrastructure.
+
+Kept free of Pulumi runtime side effects so it can be imported and unit-tested
+without a live Pulumi engine.
+"""
+
+STAGE_VMS = [
+    {"name": "lab",    "vmid": 200, "cpu": 2, "ram": 4096,  "ip": "192.168.4.200", "mac": "CA:9B:F1:85:90:C0", "clone": True, "template": "small"},
+]
+
+PROD_VMS = [
+    {"name": "gate",   "vmid": 100, "cpu": 2, "ram": 4096,  "ip": "192.168.4.100", "mac": "82:08:61:78:5A:6C", "clone": False, "template": "small"},
+    {"name": "proxy",  "vmid": 101, "cpu": 2, "ram": 8192,  "ip": "192.168.4.101", "mac": "BC:24:11:88:D8:67", "clone": False, "template": "small"},
+    {"name": "bailey", "vmid": 125, "cpu": 4, "ram": 12288, "ip": "192.168.4.125", "mac": "02:26:85:4A:AC:52", "clone": False, "template": "small"},
+    {"name": "kube-1", "vmid": 126, "cpu": 2, "ram": 8192,  "ip": "192.168.4.126", "mac": "BC:24:11:91:7B:19", "clone": False, "template": "large"},
+]
+
+
+def select_vms(stack: str) -> list[dict]:
+    """Return the VM definitions for a stack, rejecting unknown stacks."""
+    if stack == "stage":
+        return STAGE_VMS
+    if stack == "prod":
+        return PROD_VMS
+    raise ValueError(f"Unknown stack '{stack}'. Expected 'stage' or 'prod'.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,12 @@ dependencies = [
     "pulumi>=3.220.0",
     "pulumi-proxmoxve>=7.13.0",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-mock>=3.14.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared pytest fixtures and path setup for the CrowsNet test suite."""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+PULUMI_DIR = PROJECT_ROOT / "pulumi"
+
+# Make the project root importable so tests can import `crowsnet` and `utilities`.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# The pulumi/ directory is a Pulumi program, not an installable package, and its
+# modules import each other by bare name (e.g. `from components import ...`).
+# Add it to sys.path so the unit tests can import those modules directly.
+if str(PULUMI_DIR) not in sys.path:
+    sys.path.insert(0, str(PULUMI_DIR))

--- a/tests/pulumi/test_components.py
+++ b/tests/pulumi/test_components.py
@@ -1,0 +1,93 @@
+"""Tests for the ProxmoxVM component in pulumi/components.py."""
+
+import pulumi
+
+
+class _Mocks(pulumi.runtime.Mocks):
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        return [args.name + "_id", args.inputs]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):
+        return {}
+
+
+pulumi.runtime.set_mocks(_Mocks())
+
+from components import ProxmoxVM  # noqa: E402  (must follow set_mocks)
+
+
+def _make(template="small", **overrides):
+    kwargs = dict(
+        name="lab",
+        vmid=200,
+        cpu=2,
+        ram=4096,
+        ip="192.168.4.200",
+        mac="CA:9B:F1:85:90:C0",
+        clone=True,
+        template=template,
+    )
+    kwargs.update(overrides)
+    return ProxmoxVM(**kwargs)
+
+
+@pulumi.runtime.test
+def test_small_template_disk_and_clone_source():
+    vm = _make(template="small")
+
+    def check(args):
+        disks, clone = args
+        assert disks[0]["size"] == 36
+        assert clone["vm_id"] == 301
+
+    return pulumi.Output.all(vm.vm.disks, vm.vm.clone).apply(check)
+
+
+@pulumi.runtime.test
+def test_large_template_disk_and_clone_source():
+    vm = _make(template="large")
+
+    def check(args):
+        disks, clone = args
+        assert disks[0]["size"] == 130
+        assert clone["vm_id"] == 302
+
+    return pulumi.Output.all(vm.vm.disks, vm.vm.clone).apply(check)
+
+
+@pulumi.runtime.test
+def test_clone_flag_controls_full_clone():
+    vm = _make(clone=False)
+
+    def check(clone):
+        assert clone["full"] is False
+
+    return vm.vm.clone.apply(check)
+
+
+@pulumi.runtime.test
+def test_scalar_inputs_propagate():
+    vm = _make(cpu=4, ram=8192, vmid=126, mac="BC:24:11:91:7B:19")
+
+    def check(args):
+        cpu, memory, vm_id, networks = args
+        assert cpu["cores"] == 4
+        assert memory["dedicated"] == 8192
+        assert vm_id == 126
+        assert networks[0]["mac_address"] == "BC:24:11:91:7B:19"
+
+    return pulumi.Output.all(
+        vm.vm.cpu, vm.vm.memory, vm.vm.vm_id, vm.vm.network_devices
+    ).apply(check)
+
+
+@pulumi.runtime.test
+def test_ip_address_configured_with_cidr():
+    vm = _make(ip="192.168.4.200")
+
+    def check(initialization):
+        ipv4 = initialization["ip_configs"][0]["ipv4"]
+        assert ipv4["address"] == "192.168.4.200/22"
+        assert ipv4["gateway"] == "192.168.4.1"
+
+    return vm.vm.initialization.apply(check)

--- a/tests/pulumi/test_main.py
+++ b/tests/pulumi/test_main.py
@@ -1,0 +1,22 @@
+"""Tests for stack -> VM selection in pulumi/vms.py."""
+
+import pytest
+
+import vms
+
+
+def test_select_stage_returns_stage_vms():
+    selected = vms.select_vms("stage")
+    assert selected is vms.STAGE_VMS
+    assert [v["name"] for v in selected] == ["lab"]
+
+
+def test_select_prod_returns_prod_vms():
+    selected = vms.select_vms("prod")
+    assert selected is vms.PROD_VMS
+    assert [v["name"] for v in selected] == ["gate", "proxy", "bailey", "kube-1"]
+
+
+def test_select_unknown_stack_raises():
+    with pytest.raises(ValueError, match="Unknown stack"):
+        vms.select_vms("bogus")

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,90 @@
+"""Tests for the podman command construction in utilities/container.py."""
+
+from types import SimpleNamespace
+
+from utilities import container
+
+
+def _fake_run(returncode=0, recorder=None):
+    """Build a subprocess.run stand-in that records the command it received."""
+
+    def _run(cmd, *args, **kwargs):
+        if recorder is not None:
+            recorder["cmd"] = cmd
+            recorder["cwd"] = kwargs.get("cwd")
+        return SimpleNamespace(returncode=returncode)
+
+    return _run
+
+
+def test_run_container_builds_expected_command(mocker):
+    recorder = {}
+    mocker.patch.object(container.subprocess, "run", _fake_run(0, recorder))
+
+    rc = container.run_container("configure")
+
+    assert rc == 0
+    cmd = recorder["cmd"]
+    assert cmd[:6] == ["podman", "run", "-it", "--rm", "--userns=keep-id", "--network"]
+    assert "host" in cmd
+    assert f"{container.ANSIBLE_DIR}:/etc/ansible" in cmd
+    assert f"{container.PULUMI_DIR}:/pulumi" in cmd
+    assert cmd[-1] == "configure"
+
+
+def test_run_container_appends_args(mocker):
+    recorder = {}
+    mocker.patch.object(container.subprocess, "run", _fake_run(0, recorder))
+
+    container.run_container("deploy", ["stage"])
+
+    cmd = recorder["cmd"]
+    assert cmd[-2:] == ["deploy", "stage"]
+
+
+def test_run_container_no_args_does_not_append(mocker):
+    recorder = {}
+    mocker.patch.object(container.subprocess, "run", _fake_run(0, recorder))
+
+    container.run_container("test", None)
+
+    assert recorder["cmd"][-1] == "test"
+
+
+def test_run_container_returns_return_code(mocker):
+    mocker.patch.object(container.subprocess, "run", _fake_run(3))
+    assert container.run_container("configure") == 3
+
+
+def test_build_container_copies_and_cleans_up(mocker):
+    recorder = {}
+    mocker.patch.object(container.subprocess, "run", _fake_run(0, recorder))
+    copy = mocker.patch.object(container.shutil, "copy2")
+    unlink = mocker.patch("pathlib.Path.unlink")
+
+    rc = container.build_container()
+
+    assert rc == 0
+    # pyproject.toml and uv.lock copied into the docker build context
+    assert copy.call_count == 2
+    # build runs from the docker dir
+    assert recorder["cwd"] == container.DOCKER_DIR
+    assert recorder["cmd"][:3] == ["podman", "build", "."]
+    # both copied files cleaned up afterward
+    assert unlink.call_count == 2
+
+
+def test_build_container_cleans_up_on_failure(mocker):
+    mocker.patch.object(container.shutil, "copy2")
+    mocker.patch.object(
+        container.subprocess, "run", side_effect=RuntimeError("boom")
+    )
+    unlink = mocker.patch("pathlib.Path.unlink")
+
+    try:
+        container.build_container()
+    except RuntimeError:
+        pass
+
+    # finally block still removes the copied files
+    assert unlink.call_count == 2

--- a/tests/test_crowsnet.py
+++ b/tests/test_crowsnet.py
@@ -1,0 +1,92 @@
+"""Tests for the Click CLI dispatch in crowsnet.py."""
+
+import pytest
+from click.testing import CliRunner
+
+import crowsnet
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_build_calls_build_container(runner, mocker):
+    build = mocker.patch("crowsnet.build_container", return_value=0)
+    result = runner.invoke(crowsnet.cli, ["build"])
+    assert result.exit_code == 0
+    build.assert_called_once_with()
+
+
+@pytest.mark.parametrize("command", ["deploy", "destroy", "refresh"])
+@pytest.mark.parametrize("stack", ["stage", "prod"])
+def test_pulumi_commands_pass_stack(runner, mocker, command, stack):
+    run = mocker.patch("crowsnet.run_container", return_value=0)
+    result = runner.invoke(crowsnet.cli, [command, stack])
+    assert result.exit_code == 0
+    run.assert_called_once_with(command, [stack])
+
+
+@pytest.mark.parametrize("command", ["deploy", "destroy", "refresh"])
+def test_pulumi_commands_reject_unknown_stack(runner, mocker, command):
+    run = mocker.patch("crowsnet.run_container", return_value=0)
+    result = runner.invoke(crowsnet.cli, [command, "bogus"])
+    assert result.exit_code != 0
+    run.assert_not_called()
+
+
+def test_update_without_limit(runner, mocker):
+    run = mocker.patch("crowsnet.run_container", return_value=0)
+    result = runner.invoke(crowsnet.cli, ["update"])
+    assert result.exit_code == 0
+    run.assert_called_once_with("update", None)
+
+
+def test_update_with_limit(runner, mocker):
+    run = mocker.patch("crowsnet.run_container", return_value=0)
+    result = runner.invoke(crowsnet.cli, ["update", "--limit", "gate"])
+    assert result.exit_code == 0
+    run.assert_called_once_with("update", ["--limit", "gate"])
+
+
+def test_configure_without_options(runner, mocker):
+    run = mocker.patch("crowsnet.run_container", return_value=0)
+    result = runner.invoke(crowsnet.cli, ["configure"])
+    assert result.exit_code == 0
+    run.assert_called_once_with("configure", None)
+
+
+def test_configure_with_all_options(runner, mocker):
+    run = mocker.patch("crowsnet.run_container", return_value=0)
+    result = runner.invoke(
+        crowsnet.cli,
+        ["configure", "--tags", "users", "--limit", "gate", "--check"],
+    )
+    assert result.exit_code == 0
+    run.assert_called_once_with(
+        "configure", ["--tags", "users", "--limit", "gate", "--check"]
+    )
+
+
+def test_test_runs_pytest_by_default(runner, mocker):
+    run_pytest = mocker.patch("crowsnet.run_pytest", return_value=0)
+    run_integration = mocker.patch("crowsnet.run_integration", return_value=0)
+    result = runner.invoke(crowsnet.cli, ["test"])
+    assert result.exit_code == 0
+    run_pytest.assert_called_once_with()
+    run_integration.assert_not_called()
+
+
+def test_test_integration_flag_runs_integration(runner, mocker):
+    run_pytest = mocker.patch("crowsnet.run_pytest", return_value=0)
+    run_integration = mocker.patch("crowsnet.run_integration", return_value=0)
+    result = runner.invoke(crowsnet.cli, ["test", "--integration"])
+    assert result.exit_code == 0
+    run_integration.assert_called_once_with()
+    run_pytest.assert_not_called()
+
+
+def test_exit_code_propagates(runner, mocker):
+    mocker.patch("crowsnet.run_container", return_value=2)
+    result = runner.invoke(crowsnet.cli, ["deploy", "stage"])
+    assert result.exit_code == 2

--- a/utilities/testing.py
+++ b/utilities/testing.py
@@ -1,0 +1,27 @@
+"""Utilities for running the CrowsNet test suites on the host.
+
+Unit tests exercise host-side Python (the CLI, container helpers, and Pulumi
+component logic), so they run directly via ``uv`` rather than inside the ops
+container.
+"""
+
+import subprocess
+
+
+def run_pytest() -> int:
+    """Run the pytest unit suite on the host.
+
+    Returns:
+        The return code from pytest.
+    """
+    result = subprocess.run(["uv", "run", "pytest"], check=False)
+    return result.returncode
+
+
+def run_integration() -> int:
+    """Run the molecule integration suite against the stage VM.
+
+    Implemented in Phase 2 (molecule delegated driver + Pulumi lifecycle).
+    """
+    print("Integration tests are not implemented yet (Phase 2).")
+    return 1

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,12 @@ dependencies = [
     { name = "pulumi-proxmoxve" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "ansible", specifier = ">=11.6.0" },
@@ -73,6 +79,12 @@ requires-dist = [
     { name = "molecule-plugins", extras = ["vagrant"], specifier = ">=25.8.12" },
     { name = "pulumi", specifier = ">=3.220.0" },
     { name = "pulumi-proxmoxve", specifier = ">=7.13.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
 ]
 
 [[package]]
@@ -357,6 +369,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -623,6 +644,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First layer of the new three-phase testing architecture: host-side **pytest unit tests** with no infrastructure required. Covers the Click CLI dispatch, podman command construction, and Pulumi component logic.

This is Phase 1 of 3 (Phase 2: molecule delegated driver + Pulumi `stage` lifecycle; Phase 3: CI on a self-hosted runner).

## What's included

- **`tests/test_crowsnet.py`** — `CliRunner` tests for every command, asserting correct action/args dispatch and rejection of invalid stacks
- **`tests/test_container.py`** — podman `run`/`build` command construction, arg appending, return-code propagation, and cleanup-on-failure
- **`tests/pulumi/test_components.py`** — `ProxmoxVM` via `pulumi.runtime.set_mocks`, verifying small/large template → disk-size + clone-source mapping and that cpu/ram/vmid/mac/IP propagate
- **`tests/pulumi/test_main.py`** — `select_vms` stack guard

## Refactors

- Extracted the VM data + `select_vms` into **`pulumi/vms.py`** (side-effect-free, importable without a live Pulumi engine; `__main__.py` imports from it)
- Rewired `crowsnet test` to run pytest on the host via **`utilities/testing.py`**; `--integration` flag stubbed for Phase 2
- Added a dev dependency group (`pytest`, `pytest-mock`) and `[tool.pytest.ini_options]`

## Directory structure

Top-level `tests/` holds all pytest code (one config, one entry point). Molecule will live in `ansible/` in Phase 2, where the tooling discovers it.

## Verification

`uv run pytest` → **31 passed**. `./crowsnet.py test` runs the suite on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)