### PR TITLE
refactor: Run molecule via run_container, matching production

### DIFF
--- a/ansible/molecule/shared/create.yml
+++ b/ansible/molecule/shared/create.yml
@@ -7,9 +7,8 @@
   connection: local
   gather_facts: false
   vars:
-    project_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
-    pulumi_dir: "{{ project_dir }}/../../../pulumi"
-    pulumi_token_file: "{{ pulumi_dir }}/pulumi.token"
+    pulumi_dir: /pulumi
+    pulumi_token_file: /pulumi/pulumi.token
     lab_address: "{{ lookup('env', 'MOLECULE_LAB_ADDRESS') | default('192.168.4.200', true) }}"
     lab_user: "{{ lookup('env', 'MOLECULE_LAB_USER') | default('ansible', true) }}"
     lab_ssh_key: >-

--- a/ansible/molecule/shared/destroy.yml
+++ b/ansible/molecule/shared/destroy.yml
@@ -7,9 +7,8 @@
   connection: local
   gather_facts: false
   vars:
-    project_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
-    pulumi_dir: "{{ project_dir }}/../../../pulumi"
-    pulumi_token_file: "{{ pulumi_dir }}/pulumi.token"
+    pulumi_dir: /pulumi
+    pulumi_token_file: /pulumi/pulumi.token
   tasks:
     - name: Destroy the stage stack with Pulumi
       ansible.builtin.command:

--- a/crowsnet.py
+++ b/crowsnet.py
@@ -51,10 +51,11 @@ def update(limit):
 
 @cli.command()
 @click.option("--integration", is_flag=True, help="Run the molecule integration suite against the stage VM")
-def test(integration):
+@click.option("--role", default="common", help="Role to run the integration suite against")
+def test(integration, role):
     """Run the test suite (pytest unit tests by default)."""
     if integration:
-        sys.exit(run_integration())
+        sys.exit(run_integration(role))
     sys.exit(run_pytest())
 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,7 +35,9 @@ case "$ACTION" in
         pulumi refresh --yes --stack "$@"
         ;;
     test)
-        echo "Test action placeholder"
+        ROLE="${1:-common}"
+        cd "/etc/ansible/roles/${ROLE}"
+        molecule test
         ;;
     *)
         echo "Unknown action: $ACTION"

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -20,6 +20,7 @@ def _fake_run(returncode=0, recorder=None):
 def test_run_container_builds_expected_command(mocker):
     recorder = {}
     mocker.patch.object(container.subprocess, "run", _fake_run(0, recorder))
+    mocker.patch.object(container.sys.stdout, "isatty", return_value=True)
 
     rc = container.run_container("configure")
 
@@ -30,6 +31,18 @@ def test_run_container_builds_expected_command(mocker):
     assert f"{container.ANSIBLE_DIR}:/etc/ansible" in cmd
     assert f"{container.PULUMI_DIR}:/pulumi" in cmd
     assert cmd[-1] == "configure"
+
+
+def test_run_container_allocates_tty_only_when_attached(mocker):
+    recorder = {}
+    mocker.patch.object(container.subprocess, "run", _fake_run(0, recorder))
+    mocker.patch.object(container.sys.stdout, "isatty", return_value=True)
+    container.run_container("configure")
+    assert recorder["cmd"][2] == "-it"
+
+    mocker.patch.object(container.sys.stdout, "isatty", return_value=False)
+    container.run_container("configure")
+    assert recorder["cmd"][2] == "-i"
 
 
 def test_run_container_appends_args(mocker):

--- a/tests/test_crowsnet.py
+++ b/tests/test_crowsnet.py
@@ -82,8 +82,16 @@ def test_test_integration_flag_runs_integration(runner, mocker):
     run_integration = mocker.patch("crowsnet.run_integration", return_value=0)
     result = runner.invoke(crowsnet.cli, ["test", "--integration"])
     assert result.exit_code == 0
-    run_integration.assert_called_once_with()
+    run_integration.assert_called_once_with("common")
     run_pytest.assert_not_called()
+
+
+def test_test_integration_accepts_role(runner, mocker):
+    mocker.patch("crowsnet.run_pytest", return_value=0)
+    run_integration = mocker.patch("crowsnet.run_integration", return_value=0)
+    result = runner.invoke(crowsnet.cli, ["test", "--integration", "--role", "jellyfin"])
+    assert result.exit_code == 0
+    run_integration.assert_called_once_with("jellyfin")
 
 
 def test_exit_code_propagates(runner, mocker):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -22,38 +22,18 @@ def test_run_pytest_invokes_uv(mocker):
     assert recorder["cmd"] == ["uv", "run", "pytest"]
 
 
-def test_run_integration_builds_container_command(mocker):
-    recorder = {}
-    mocker.patch.object(testing.subprocess, "run", _fake_run(0, recorder))
-    mocker.patch("pathlib.Path.exists", return_value=True)
-    mocker.patch("pathlib.Path.read_text", return_value="secret-token\n")
-
+def test_run_integration_dispatches_test_action(mocker):
+    run_container = mocker.patch.object(testing, "run_container", return_value=0)
     assert testing.run_integration() == 0
-
-    cmd = recorder["cmd"]
-    assert cmd[0:2] == ["podman", "run"]
-    assert "--network" in cmd and "host" in cmd
-    assert f"{testing.PROJECT_ROOT}:/workspace" in cmd
-    # runs from the role's scenario directory under the mounted repo
-    assert "/workspace/ansible/roles/common" in cmd
-    # token passed through the environment, not a world-readable mount
-    assert "PULUMI_ACCESS_TOKEN=secret-token" in cmd
-    # molecule is the entrypoint, given the `test` subcommand
-    assert cmd[-4:] == ["--entrypoint", "molecule", testing.CONTAINER_NAME, "test"]
+    run_container.assert_called_once_with("test", ["common"])
 
 
-def test_run_integration_accepts_role(mocker):
-    recorder = {}
-    mocker.patch.object(testing.subprocess, "run", _fake_run(0, recorder))
-    mocker.patch("pathlib.Path.exists", return_value=True)
-    mocker.patch("pathlib.Path.read_text", return_value="t")
-
+def test_run_integration_forwards_role(mocker):
+    run_container = mocker.patch.object(testing, "run_container", return_value=0)
     testing.run_integration("jellyfin")
-    assert "/workspace/ansible/roles/jellyfin" in recorder["cmd"]
+    run_container.assert_called_once_with("test", ["jellyfin"])
 
 
 def test_run_integration_propagates_return_code(mocker):
-    mocker.patch.object(testing.subprocess, "run", _fake_run(5))
-    mocker.patch("pathlib.Path.exists", return_value=True)
-    mocker.patch("pathlib.Path.read_text", return_value="t")
+    mocker.patch.object(testing, "run_container", return_value=5)
     assert testing.run_integration() == 5

--- a/utilities/container.py
+++ b/utilities/container.py
@@ -2,6 +2,7 @@
 
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -48,10 +49,13 @@ def run_container(action: str, args: list[str] | None = None) -> int:
     Returns:
         The return code from podman run.
     """
+    # Allocate a TTY only when attached to one; CI runners have no TTY.
+    tty_flag = "-it" if sys.stdout.isatty() else "-i"
+
     cmd = [
         "podman",
         "run",
-        "-it",
+        tty_flag,
         "--rm",
         "--userns=keep-id",
         "--network",

--- a/utilities/testing.py
+++ b/utilities/testing.py
@@ -7,11 +7,8 @@ keys, and the Ansible collections configured.
 """
 
 import subprocess
-from pathlib import Path
 
-from utilities.container import CONTAINER_NAME
-
-PROJECT_ROOT = Path(__file__).parent.parent
+from utilities.container import run_container
 
 
 def run_pytest() -> int:
@@ -27,10 +24,11 @@ def run_pytest() -> int:
 def run_integration(role: str = "common") -> int:
     """Run the molecule integration suite for a role inside the ops container.
 
-    Molecule provisions the lab VM via Pulumi, converges the role, checks
-    idempotency, and destroys the VM. The whole repo is mounted at /workspace so
-    the scenario's repo-relative paths (to pulumi/ and group_vars/) resolve, and
-    molecule runs from the role directory to pick up its `default` scenario.
+    Dispatches the container's `test` action through the same `run_container`
+    path as production (configure/deploy), so molecule sees the production mount
+    layout (ansible -> /etc/ansible, pulumi -> /pulumi) and user-namespace mapping.
+    Molecule then provisions the lab VM via Pulumi, converges the role, checks
+    idempotency, and destroys the VM.
 
     Args:
         role: The role whose molecule scenario to run.
@@ -38,26 +36,4 @@ def run_integration(role: str = "common") -> int:
     Returns:
         The return code from the container.
     """
-    token_file = PROJECT_ROOT / "pulumi" / "pulumi.token"
-    token = token_file.read_text().strip() if token_file.exists() else ""
-
-    cmd = [
-        "podman",
-        "run",
-        "--rm",
-        "--network",
-        "host",
-        "--volume",
-        f"{PROJECT_ROOT}:/workspace",
-        "--workdir",
-        f"/workspace/ansible/roles/{role}",
-        "--env",
-        f"PULUMI_ACCESS_TOKEN={token}",
-        "--entrypoint",
-        "molecule",
-        CONTAINER_NAME,
-        "test",
-    ]
-
-    result = subprocess.run(cmd, check=False)
-    return result.returncode
+    return run_container("test", [role])


### PR DESCRIPTION
## Summary

Drives the molecule integration suite through the **same `run_container` path as production** (`configure`/`deploy`) instead of a hand-rolled `podman run`. Molecule now sees the production mount layout (`ansible → /etc/ansible`, `pulumi → /pulumi`) and `--userns=keep-id` user mapping — so integration exercises the real container invocation, not a bespoke one.

Follow-up to #72.

## What changed

- **`docker/entrypoint.sh`** — implement the `test` action: `cd /etc/ansible/roles/$ROLE && molecule test` (defaults to `common`).
- **`utilities/container.py`** — make `run_container` TTY-aware (`-it` only when attached to a TTY) so the integration suite is CI-safe ahead of Phase 3.
- **`utilities/testing.py`** — collapse `run_integration` to `run_container("test", [role])`; drop the `/workspace` full-repo mount and the `PULUMI_ACCESS_TOKEN` env-var workaround. The Pulumi token is now read from `/pulumi/pulumi.token` under `--userns=keep-id`, exactly as `deploy` already does.
- **`crowsnet.py`** — add `--role` to the `test` command (defaults to `common`).
- **`ansible/molecule/shared/{create,destroy}.yml`** — hardcode Pulumi at `/pulumi` instead of the repo-relative `../../../pulumi` climb, which only resolved under the old sibling `/workspace` mount.
- **tests** — cover the delegation, the TTY flag (attached vs not), and `--role`.

### Why the Pulumi path had to change
Production mounts `ansible` and `pulumi` as separate, non-adjacent paths. The old molecule playbooks located Pulumi by climbing `MOLECULE_PROJECT_DIRECTORY/../../../pulumi`, which only works when `/workspace` keeps them as siblings. Everything else molecule needs (shared playbooks, `group_vars/all`, `roles/requirements.yml`) already resolves inside `/etc/ansible`.

## Verification

- `uv run pytest` → **37 passed**
- `ansible-lint` → clean (production profile)
- `./crowsnet.py build` → image rebuilt with the new entrypoint
- **Live run** `./crowsnet.py test --integration` → **exit 0**: `pulumi up (stage)` → prepare → converge → **idempotence `changed=0`** → verify (sshd + `chasty2`) → `pulumi destroy`, VM torn down. Confirmed tasks run from `/etc/ansible/...` (production mounts, no `/workspace`).

## Out of scope / follow-ups

- Add `update_cache: true` to the `common` role packages (latent bug noted in #72).
- Phase 3 CI wiring on the self-hosted runner.
- Multi-role / discover-all `test` action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)