### PR TITLE
docs: Document pytest and Molecule testing framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,6 @@
 
 # Testing
 ./crowsnet.py test                                # Unit tests (pytest, host-side, no infra)
-uv run pytest                                     # Same unit suite, run directly
 ./crowsnet.py test --integration                  # Molecule integration suite (role: common)
 ./crowsnet.py test --integration --role <role>    # Integration suite for a specific role
 ```
@@ -39,7 +38,7 @@ The suite has two layers (a third, CI on a self-hosted runner, is still pending)
 
 - **Unit (pytest)** — fast, host-only, no infrastructure. Covers the Click CLI
   dispatch, podman command construction, and Pulumi component logic. Lives in
-  `tests/`. Run on every change via `./crowsnet.py test` (or `uv run pytest`).
+  `tests/`. Run on every change via `./crowsnet.py test`.
 - **Integration (Molecule)** — provisions the real `stage` lab VM via Pulumi,
   converges a role, checks idempotency, then tears the VM down (destroy always
   runs last, even on failure). Run when changing an Ansible role via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,27 @@
 
 # Maintenance
 ./crowsnet.py update                       # Update and reboot all VMs
-./crowsnet.py test                         # Run tests
+
+# Testing
+./crowsnet.py test                                # Unit tests (pytest, host-side, no infra)
+uv run pytest                                     # Same unit suite, run directly
+./crowsnet.py test --integration                  # Molecule integration suite (role: common)
+./crowsnet.py test --integration --role <role>    # Integration suite for a specific role
 ```
 
-## Workflow Patterns (TODO after implementing molecule testing)
+## Testing Workflow
+
+The suite has two layers (a third, CI on a self-hosted runner, is still pending):
+
+- **Unit (pytest)** — fast, host-only, no infrastructure. Covers the Click CLI
+  dispatch, podman command construction, and Pulumi component logic. Lives in
+  `tests/`. Run on every change via `./crowsnet.py test` (or `uv run pytest`).
+- **Integration (Molecule)** — provisions the real `stage` lab VM via Pulumi,
+  converges a role, checks idempotency, then tears the VM down (destroy always
+  runs last, even on failure). Run when changing an Ansible role via
+  `./crowsnet.py test --integration [--role <role>]`. Runs inside the ops
+  container and requires Pulumi `stage` access. See `ansible/CLAUDE.md` for how
+  to add a Molecule scenario to a role.
 
 ## Directory Structure
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ crowsnet/
 │   ├── Dockerfile      # Unified CrowsNet container (Ansible + Pulumi)
 │   └── entrypoint.sh   # Action dispatcher (configure, deploy, etc.)
 ├── utilities/          # Python utilities for container operations
+├── tests/              # Host-side pytest unit tests (CLI, container, Pulumi)
 └── crowsnet.py         # CLI entry point for all operations
 ```
 

--- a/ansible/CLAUDE.md
+++ b/ansible/CLAUDE.md
@@ -64,7 +64,7 @@ Place the scenario under the role:
 roles/<role>/molecule/default/
 ├── molecule.yml      # scenario config
 ├── converge.yml      # applies the role
-└── verify.yml        # optional smoke checks
+└── verify.yml        # required smoke checks
 ```
 
 The lifecycle playbooks (`create`, `prepare`, `destroy`) are written **once** in
@@ -116,9 +116,10 @@ verifier:
     - <role> # noqa syntax-check[specific]
 ```
 
-**`verify.yml`** (optional) — minimal smoke checks asserting the role's key
-effects (a service is running, a user exists, etc.). Do **not** test idempotency
-here; molecule's built-in `idempotence` step handles that.
+**`verify.yml`** (required) — minimal smoke checks asserting the role's key
+effects (a service is running, a user exists, etc.). Every scenario must include
+one. Do **not** test idempotency here; molecule's built-in `idempotence` step
+handles that.
 
 ## Formatting
 - End each `.yml` file with a newline

--- a/ansible/CLAUDE.md
+++ b/ansible/CLAUDE.md
@@ -33,8 +33,8 @@ role_name/
 │   ├── role_name_packages.yml      # Package management tasks
 │   ├── role_name_services.yml      # Service management tasks
 │   └── role_name_firewalld.yml     # Firewall configuration tasks
-├── tests/
-│   └── test.yml          # Test playbook for the role
+├── molecule/
+│   └── default/          # Molecule integration scenario (see Molecule Testing)
 ├── vars/main.yml         # Role variables
 ├── handlers/main.yml     # Event handlers
 ├── templates/            # Jinja2 templates
@@ -43,10 +43,9 @@ role_name/
 
 This standardization allows predictable role structure and granular control over which aspects of configuration to apply during playbook runs.
 
-### Role Testing
-Each role should have a `tests/` directory containing a `test.yml` playbook that:
-- Runs the role and its dependencies
-- Targets the host `lab`
+> **Note:** Roles are tested with Molecule (see below), not the legacy
+> `tests/test.yml` playbook. New roles get a `molecule/` scenario instead of a
+> `tests/` directory.
 
 ## Molecule Testing
 

--- a/ansible/CLAUDE.md
+++ b/ansible/CLAUDE.md
@@ -48,5 +48,78 @@ Each role should have a `tests/` directory containing a `test.yml` playbook that
 - Runs the role and its dependencies
 - Targets the host `lab`
 
+## Molecule Testing
+
+Roles are integration-tested with Molecule. A `molecule test` run provisions the
+real `stage` lab VM via Pulumi, converges the role, checks **idempotency**, runs
+the verifier, then destroys the VM (destroy always runs last, even on failure).
+
+Run a role's scenario from the repo root:
+```bash
+./crowsnet.py test --integration --role <role>   # defaults to `common`
+```
+
+### Adding a scenario to a role
+Place the scenario under the role:
+```
+roles/<role>/molecule/default/
+├── molecule.yml      # scenario config
+├── converge.yml      # applies the role
+└── verify.yml        # optional smoke checks
+```
+
+The lifecycle playbooks (`create`, `prepare`, `destroy`) are written **once** in
+`ansible/molecule/shared/` and reused by every role — do **not** reimplement them
+per role. The fastest path to a new scenario is to copy
+`roles/common/molecule/default/` and adjust the role name.
+
+**`molecule.yml`** — `driver: default`; one platform named `lab`; a galaxy
+dependency pointing at `../requirements.yml`; `provisioner.playbooks` wiring the
+three shared playbooks; `ANSIBLE_ROLES_PATH` set to the roles directory; and
+`verifier: ansible`:
+```yaml
+---
+driver:
+  name: default
+
+platforms:
+  - name: lab
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/../requirements.yml
+
+provisioner:
+  name: ansible
+  playbooks:
+    create: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/create.yml
+    prepare: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/prepare.yml
+    destroy: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/destroy.yml
+  env:
+    ANSIBLE_HOST_KEY_CHECKING: "false"
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
+
+verifier:
+  name: ansible
+```
+
+**`converge.yml`** — `hosts: all`, `become: true`, loads shared vars from
+`group_vars/all`, and lists the role:
+```yaml
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../group_vars/all"
+  roles:
+    - <role> # noqa syntax-check[specific]
+```
+
+**`verify.yml`** (optional) — minimal smoke checks asserting the role's key
+effects (a service is running, a user exists, etc.). Do **not** test idempotency
+here; molecule's built-in `idempotence` step handles that.
+
 ## Formatting
 - End each `.yml` file with a newline

--- a/ansible/CLAUDE.md
+++ b/ansible/CLAUDE.md
@@ -64,7 +64,7 @@ Place the scenario under the role:
 roles/<role>/molecule/default/
 ├── molecule.yml      # scenario config
 ├── converge.yml      # applies the role
-└── verify.yml        # required smoke checks
+└── verify.yml        # smoke checks
 ```
 
 The lifecycle playbooks (`create`, `prepare`, `destroy`) are written **once** in
@@ -116,7 +116,7 @@ verifier:
     - <role> # noqa syntax-check[specific]
 ```
 
-**`verify.yml`** (required) — minimal smoke checks asserting the role's key
+**`verify.yml`** — smoke checks asserting the role's key
 effects (a service is running, a user exists, etc.). Every scenario must include
 one. Do **not** test idempotency here; molecule's built-in `idempotence` step
 handles that.


### PR DESCRIPTION
## Summary

Closes #75. Documents the testing framework (built in #70, #72, #74) in the project's `CLAUDE.md` files so Claude Code can run and extend the tests without re-deriving the framework each time. **Documentation-only** — no code changes.

## What changed

- **`CLAUDE.md`**
  - Added a dedicated **Testing** command block; all testing routes through `./crowsnet.py test` (unit) and `./crowsnet.py test --integration [--role <role>]` (Molecule).
  - Filled the `## Workflow Patterns (TODO after implementing molecule testing)` placeholder with a **Testing Workflow** section describing the two-layer model (Phase 3 CI still pending).
  - Added `tests/` to the directory structure.
- **`ansible/CLAUDE.md`**
  - Added a **Molecule Testing** section: per-role scenario layout, the shared lifecycle playbooks in `ansible/molecule/shared/` (written once, reused), annotated `molecule.yml`/`converge.yml`/`verify.yml` templates, and a pointer to copy `roles/common/` as the reference.
  - Replaced the legacy `tests/test.yml` role-testing pattern with `molecule/` in the role structure, with a note about the change.
  - `verify.yml` smoke checks are documented as required for every scenario.

## Verification

- `./crowsnet.py test` → **37 passed** (confirms the documented unit command).
- Cross-checked every documented command/path against `crowsnet.py`, `utilities/testing.py`, `ansible/molecule/shared/*`, and `ansible/roles/common/molecule/default/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)