### PR TITLE
feat: Add fzf integration to common role

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ crowsnet/
 - All work should be done in a branch outside of main
 - Each goal should be accomplished in its own branch
 - Commit early and often, after each meaningful change
+- Always run the test suite (`./crowsnet.py test`) and have it pass before committing
 - When done, check in with the user for approval
 - Submit a PR to merge into main with a semantic tag in the title (e.g., `feat:`, `fix:`, `refactor:`, `docs:`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ crowsnet/
 - All work should be done in a branch outside of main
 - Each goal should be accomplished in its own branch
 - Commit early and often, after each meaningful change
-- Always run the test suite (`./crowsnet.py test`) and have it pass before committing
+- Always run the test suite (`./crowsnet.py test [--integration]`) and have it pass before committing
 - When done, check in with the user for approval
 - Submit a PR to merge into main with a semantic tag in the title (e.g., `feat:`, `fix:`, `refactor:`, `docs:`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ crowsnet/
 - All work should be done in a branch outside of main
 - Each goal should be accomplished in its own branch
 - Commit early and often, after each meaningful change
-- Always run the test suite (`./crowsnet.py test [--integration]`) and have it pass before committing
+- Always run the testing workflow and have it pass before committing
 - When done, check in with the user for approval
 - Submit a PR to merge into main with a semantic tag in the title (e.g., `feat:`, `fix:`, `refactor:`, `docs:`)
 

--- a/ansible/roles/common/molecule/default/verify.yml
+++ b/ansible/roles/common/molecule/default/verify.yml
@@ -19,3 +19,14 @@
       ansible.builtin.getent:
         database: passwd
         key: chasty2
+
+    - name: Read chasty2 .bashrc
+      ansible.builtin.slurp:
+        src: /home/chasty2/.bashrc
+      register: chasty2_bashrc
+
+    - name: Assert fzf bash integration is configured
+      ansible.builtin.assert:
+        that:
+          - "'fzf --bash' in (chasty2_bashrc.content | b64decode)"
+        fail_msg: "fzf bash integration missing from chasty2 .bashrc"

--- a/ansible/roles/common/molecule/default/verify.yml
+++ b/ansible/roles/common/molecule/default/verify.yml
@@ -23,10 +23,10 @@
     - name: Read chasty2 .bashrc
       ansible.builtin.slurp:
         src: /home/chasty2/.bashrc
-      register: chasty2_bashrc
+      register: common_chasty2_bashrc
 
     - name: Assert fzf bash integration is configured
       ansible.builtin.assert:
         that:
-          - "'fzf --bash' in (chasty2_bashrc.content | b64decode)"
+          - "'fzf --bash' in (common_chasty2_bashrc.content | b64decode)"
         fail_msg: "fzf bash integration missing from chasty2 .bashrc"

--- a/ansible/roles/common/tasks/users.yml
+++ b/ansible/roles/common/tasks/users.yml
@@ -54,3 +54,12 @@
         key: "{{ item.public_ssh_key }}"
         state: present
       with_items: "{{ common_ssh_keys }}"
+
+    - name: Enable fzf bash integration for admin users
+      ansible.builtin.lineinfile:
+        path: "/home/{{ item.name }}/.bashrc"
+        line: 'eval "$(fzf --bash)"'
+        owner: "{{ item.name }}"
+        group: "{{ item.gid }}"
+        create: false
+      with_items: "{{ admin_users }}"


### PR DESCRIPTION
## Summary
Resolves #41 by wiring fzf's bash integration into admin users' shells on CrowsNet machines. `fzf` was already installed via the common role's package list; this sources its key-bindings and completion at shell startup.

- Append `eval "$(fzf --bash)"` to each `admin_users` member's `.bashrc` via an idempotent `lineinfile` task in the common role
- Add a Molecule smoke check to the common role's `default` scenario asserting the line is present in `chasty2`'s `.bashrc`
- Add a CLAUDE.md git convention: run the test suite and have it pass before committing

## Note
`fzf --bash` requires fzf ≥ 0.48. If a target distro ships an older `fzf`, the eval will error on interactive login and we may want to guard it.

## Testing
- `./crowsnet.py test` — 37 passed
- `ansible-lint` on changed files — passed (production profile)
- `./crowsnet.py test --integration --role common` — converge, idempotence (changed=0), and verify (incl. new fzf assertion) all passed; stage VM destroyed cleanly

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)