### PR TITLE
fix: Update apt cache on common role run

### DIFF
--- a/ansible/roles/common/tasks/packages.yml
+++ b/ansible/roles/common/tasks/packages.yml
@@ -4,6 +4,11 @@
   become: true
   tags: packages
   block:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+
     - name: Install base softwares
       ansible.builtin.package:
         name: "{{ item }}"


### PR DESCRIPTION
## Summary
Refresh the apt cache as the first task in the `common` role's package block, before installing base packages.

Previously a freshly provisioned VM relied on a manual full update after creation to populate package metadata. This made the `common` role's package installs depend on an out-of-band step. Updating the cache here makes the role self-contained on first run and avoids installs pulling stale metadata.

`cache_valid_time: 3600` keeps the task idempotent so molecule's back-to-back converge passes its idempotence check.

Resolves #73

## Testing
- `./crowsnet.py test` — 37 passed
- `./crowsnet.py test --integration --role common` — converge, idempotence (changed=0), and verifier all passed; VM destroyed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)