### PR TITLE
chore: Share and normalize Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(./crowsnet.py build:*)",
+      "Bash(./crowsnet.py test:*)",
+      "Bash(gh issue:*)",
+      "Bash(ls:*)"
+    ],
+    "deny": [
+      "Bash(./crowsnet.py destroy:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,16 @@
 .vscode
 ssh-keys/
 vault.pass
-ansible/hosts
 .venv/
 .python-version
-.ansible
-.claude
 __pycache__/
+
+## Claude
+.claude/settings.local.json
+
+## Ansible
+.ansible
+ansible/hosts
 
 ## Pulumi
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .vscode
-ssh-keys/
-vault.pass
 .venv/
 .python-version
 __pycache__/
@@ -11,6 +9,8 @@ __pycache__/
 ## Ansible
 .ansible
 ansible/hosts
+ssh-keys/
+vault.pass
 
 ## Pulumi
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ crowsnet/
 4. **Single responsibility** - Functions do one thing, under 50 lines
 5. **Early returns** - Guard clauses over nested conditionals
 6. **Match existing patterns** - Follow the file's conventions exactly
+7. **Use uv for Python** - Invoke all Python tooling through `uv` (e.g. `uv run pytest`, `uv run python ...`, `uv pip ...`); never bare `python`/`pip`/`pytest`
 
 
 ## Git Conventions


### PR DESCRIPTION
## Summary

Promotes the personal Claude Code permission allowlist to a tracked, shared `.claude/settings.json` so every contributor inherits the same safe baseline, and tidies related config.

- **Share & normalize permissions** — new tracked `.claude/settings.json`. All Bash rules use the documented `:*` prefix form (previously a mix of `:*` and unreliable space-`*` patterns), the redundant `gh issue view` rule is dropped (covered by `gh issue:*`), and a small `deny` guardrail blocks `./crowsnet.py destroy`.
- **.gitignore** — un-ignore `.claude` (keeping only the personal `settings.local.json` ignored), and group the scattered Ansible entries under an `## Ansible` header to match the existing `## Pulumi` section.
- **CLAUDE.md** — document that Python tooling is invoked through `uv`. _(Small extra fix uncovered while reviewing the plan for this PR, folded in here.)_

The personal `.claude/settings.local.json` remains gitignored and is not part of this PR.

## Verification

- `git check-ignore .claude/settings.json` → not ignored (tracked); `.claude/settings.local.json` → still ignored
- Both settings files are valid JSON
- `./crowsnet.py test` → 37 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)