### PR TITLE
feat: Create 'dev' Pulumi stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@
 ./crowsnet.py build                        # Build the CrowsNet container
 
 # Infrastructure (Pulumi)
-./crowsnet.py deploy <stage|prod>          # Deploy infrastructure
-./crowsnet.py destroy <stage|prod>         # Destroy infrastructure
-./crowsnet.py refresh <stage|prod>         # Refresh infrastructure state
+./crowsnet.py deploy <stage|dev|prod>      # Deploy infrastructure
+./crowsnet.py destroy <stage|dev|prod>     # Destroy infrastructure
+./crowsnet.py refresh <stage|dev|prod>     # Refresh infrastructure state
 
 # Configuration (Ansible)
 ./crowsnet.py configure                    # Full site deployment
@@ -39,7 +39,7 @@ The suite has two layers (a third, CI on a self-hosted runner, is still pending)
 - **Unit (pytest)** — fast, host-only, no infrastructure. Covers the Click CLI
   dispatch, podman command construction, and Pulumi component logic. Lives in
   `tests/`. Run on every change via `./crowsnet.py test`.
-- **Integration (Molecule)** — provisions the real `stage` lab VM via Pulumi,
+- **Integration (Molecule)** — provisions the real `stage` VM via Pulumi,
   converges a role, checks idempotency, then tears the VM down (destroy always
   runs last, even on failure). Run when changing an Ansible role via
   `./crowsnet.py test --integration [--role <role>]`. Runs inside the ops

--- a/ansible/CLAUDE.md
+++ b/ansible/CLAUDE.md
@@ -50,7 +50,7 @@ This standardization allows predictable role structure and granular control over
 ## Molecule Testing
 
 Roles are integration-tested with Molecule. A `molecule test` run provisions the
-real `stage` lab VM via Pulumi, converges the role, checks **idempotency**, runs
+real `stage` VM via Pulumi, converges the role, checks **idempotency**, runs
 the verifier, then destroys the VM (destroy always runs last, even on failure).
 
 Run a role's scenario from the repo root:
@@ -72,7 +72,7 @@ The lifecycle playbooks (`create`, `prepare`, `destroy`) are written **once** in
 per role. The fastest path to a new scenario is to copy
 `roles/common/molecule/default/` and adjust the role name.
 
-**`molecule.yml`** — `driver: default`; one platform named `lab`; a galaxy
+**`molecule.yml`** — `driver: default`; one platform named `stage`; a galaxy
 dependency pointing at `../requirements.yml`; `provisioner.playbooks` wiring the
 three shared playbooks; `ANSIBLE_ROLES_PATH` set to the roles directory; and
 `verifier: ansible`:
@@ -82,7 +82,7 @@ driver:
   name: default
 
 platforms:
-  - name: lab
+  - name: stage
 
 dependency:
   name: galaxy

--- a/ansible/molecule/shared/create.yml
+++ b/ansible/molecule/shared/create.yml
@@ -1,6 +1,6 @@
 ---
 # Shared molecule create playbook (reused by every role scenario).
-# Provisions the Pulumi `stage` stack (the lab VM), waits for SSH, and writes
+# Provisions the Pulumi `stage` stack (the stage VM), waits for SSH, and writes
 # the molecule instance config so converge knows how to connect.
 - name: Create
   hosts: localhost
@@ -9,10 +9,10 @@
   vars:
     pulumi_dir: /pulumi
     pulumi_token_file: /pulumi/pulumi.token
-    lab_address: "{{ lookup('env', 'MOLECULE_LAB_ADDRESS') | default('192.168.4.200', true) }}"
-    lab_user: "{{ lookup('env', 'MOLECULE_LAB_USER') | default('ansible', true) }}"
-    lab_ssh_key: >-
-      {{ lookup('env', 'MOLECULE_LAB_SSH_KEY')
+    stage_address: "{{ lookup('env', 'MOLECULE_STAGE_ADDRESS') | default('192.168.4.250', true) }}"
+    stage_user: "{{ lookup('env', 'MOLECULE_STAGE_USER') | default('ansible', true) }}"
+    stage_ssh_key: >-
+      {{ lookup('env', 'MOLECULE_STAGE_SSH_KEY')
          | default(lookup('env', 'HOME') ~ '/.ssh/id_ed25519', true) }}
   tasks:
     - name: Deploy the stage stack with Pulumi
@@ -25,9 +25,9 @@
              | default(lookup('file', pulumi_token_file), true) }}
       changed_when: true
 
-    - name: Wait for the lab VM SSH to become reachable
+    - name: Wait for the stage VM SSH to become reachable
       ansible.builtin.wait_for:
-        host: "{{ lab_address }}"
+        host: "{{ stage_address }}"
         port: 22
         delay: 10
         timeout: 300
@@ -35,11 +35,11 @@
     - name: Build the molecule instance config
       ansible.builtin.set_fact:
         instance_conf:
-          - instance: lab
-            address: "{{ lab_address }}"
-            user: "{{ lab_user }}"
+          - instance: stage
+            address: "{{ stage_address }}"
+            user: "{{ stage_user }}"
             port: 22
-            identity_file: "{{ lab_ssh_key }}"
+            identity_file: "{{ stage_ssh_key }}"
 
     - name: Write the molecule instance config
       ansible.builtin.copy:

--- a/ansible/molecule/shared/prepare.yml
+++ b/ansible/molecule/shared/prepare.yml
@@ -1,6 +1,6 @@
 ---
 # Shared molecule prepare playbook (reused by every role scenario).
-# Refreshes the apt cache on the freshly-cloned lab VM so package installs
+# Refreshes the apt cache on the freshly-cloned stage VM so package installs
 # resolve current versions (the template's cache is stale and pins versions
 # whose .deb files have aged out of the mirror).
 - name: Prepare

--- a/ansible/roles/common/molecule/default/molecule.yml
+++ b/ansible/roles/common/molecule/default/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: default
 
 platforms:
-  - name: lab
+  - name: stage
 
 dependency:
   name: galaxy

--- a/crowsnet.py
+++ b/crowsnet.py
@@ -19,21 +19,21 @@ def build():
 
 
 @cli.command()
-@click.argument("stack", type=click.Choice(["stage", "prod"]))
+@click.argument("stack", type=click.Choice(["stage", "dev", "prod"]))
 def deploy(stack):
     """Deploy infrastructure with Pulumi."""
     sys.exit(run_container("deploy", [stack]))
 
 
 @cli.command()
-@click.argument("stack", type=click.Choice(["stage", "prod"]))
+@click.argument("stack", type=click.Choice(["stage", "dev", "prod"]))
 def destroy(stack):
     """Destroy infrastructure with Pulumi."""
     sys.exit(run_container("destroy", [stack]))
 
 
 @cli.command()
-@click.argument("stack", type=click.Choice(["stage", "prod"]))
+@click.argument("stack", type=click.Choice(["stage", "dev", "prod"]))
 def refresh(stack):
     """Refresh infrastructure state with Pulumi."""
     sys.exit(run_container("refresh", [stack]))

--- a/pulumi/vms.py
+++ b/pulumi/vms.py
@@ -5,6 +5,10 @@ without a live Pulumi engine.
 """
 
 STAGE_VMS = [
+    {"name": "stage",  "vmid": 250, "cpu": 2, "ram": 4096,  "ip": "192.168.4.250", "mac": "BC:24:11:1D:90:74", "clone": True, "template": "small"},
+]
+
+DEV_VMS = [
     {"name": "lab",    "vmid": 200, "cpu": 2, "ram": 4096,  "ip": "192.168.4.200", "mac": "CA:9B:F1:85:90:C0", "clone": True, "template": "small"},
 ]
 
@@ -20,6 +24,8 @@ def select_vms(stack: str) -> list[dict]:
     """Return the VM definitions for a stack, rejecting unknown stacks."""
     if stack == "stage":
         return STAGE_VMS
+    if stack == "dev":
+        return DEV_VMS
     if stack == "prod":
         return PROD_VMS
-    raise ValueError(f"Unknown stack '{stack}'. Expected 'stage' or 'prod'.")
+    raise ValueError(f"Unknown stack '{stack}'. Expected 'stage', 'dev', or 'prod'.")

--- a/tests/pulumi/test_main.py
+++ b/tests/pulumi/test_main.py
@@ -8,6 +8,12 @@ import vms
 def test_select_stage_returns_stage_vms():
     selected = vms.select_vms("stage")
     assert selected is vms.STAGE_VMS
+    assert [v["name"] for v in selected] == ["stage"]
+
+
+def test_select_dev_returns_dev_vms():
+    selected = vms.select_vms("dev")
+    assert selected is vms.DEV_VMS
     assert [v["name"] for v in selected] == ["lab"]
 
 


### PR DESCRIPTION
Completes the final two checklist items of #69: splits the single `stage`-stack test VM into two roles.

## Changes
- **`dev` stack** (new) holds the persistent `lab` sandbox VM, keeping its existing identity (vmid 200, `192.168.4.200`, MAC `CA:9B:F1:85:90:C0`).
- **`stage` stack** now holds a new ephemeral `stage` VM (vmid 250, `192.168.4.250`, MAC `BC:24:11:1D:90:74`) used by the Molecule integration suite.
- Added `dev` to the `deploy`/`destroy`/`refresh` CLI choices and to `select_vms`.
- Fully renamed the Molecule `lab` platform/env vars/instance to `stage`, now pointing at `192.168.4.250`.
- Updated unit tests and docs (`CLAUDE.md`, `ansible/CLAUDE.md`).

## Verification
- `./crowsnet.py test` → 38 passed
- `uv run ruff check` → clean
- `dev` stack created and both stacks deployed successfully (`lab` in `dev`, `stage` in `stage`).

Refs #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)