### PR TITLE
feat: Add dev role for Claude sandbox VMs

### DIFF
--- a/ansible/roles/dev/molecule/default/converge.yml
+++ b/ansible/roles/dev/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    # common creates the chasty2 user that the dev role installs Claude for.
+    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../group_vars/all"
+  roles:
+    - common # noqa syntax-check[specific]
+    - dev # noqa syntax-check[specific]

--- a/ansible/roles/dev/molecule/default/converge.yml
+++ b/ansible/roles/dev/molecule/default/converge.yml
@@ -3,7 +3,6 @@
   hosts: all
   become: true
   vars_files:
-    # common creates the chasty2 user that the dev role installs Claude for.
     - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../group_vars/all"
   roles:
     - common # noqa syntax-check[specific]

--- a/ansible/roles/dev/molecule/default/molecule.yml
+++ b/ansible/roles/dev/molecule/default/molecule.yml
@@ -1,0 +1,24 @@
+---
+driver:
+  name: default
+
+platforms:
+  - name: stage
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/../requirements.yml
+
+provisioner:
+  name: ansible
+  playbooks:
+    create: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/create.yml
+    prepare: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/prepare.yml
+    destroy: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/destroy.yml
+  env:
+    ANSIBLE_HOST_KEY_CHECKING: "false"
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
+
+verifier:
+  name: ansible

--- a/ansible/roles/dev/molecule/default/verify.yml
+++ b/ansible/roles/dev/molecule/default/verify.yml
@@ -1,0 +1,38 @@
+---
+# Minimal smoke checks for the dev role. Idempotency is verified separately by
+# molecule's built-in `idempotence` step, not here.
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+
+    - name: Assert the claude-code package is installed
+      ansible.builtin.assert:
+        that:
+          - "'claude-code' in ansible_facts.packages"
+        fail_msg: "claude-code apt package is not installed"
+
+    - name: Locate the claude binary on PATH
+      ansible.builtin.command: which claude
+      changed_when: false
+
+    - name: Stat the secrets mountpoint
+      ansible.builtin.stat:
+        path: /mnt/secrets
+      register: dev_secrets_stat
+
+    - name: Assert /mnt/secrets is owned by chasty2 with mode 0770
+      ansible.builtin.assert:
+        that:
+          - dev_secrets_stat.stat.isdir
+          - dev_secrets_stat.stat.pw_name == "chasty2"
+          - dev_secrets_stat.stat.gr_name == "chasty2"
+          - dev_secrets_stat.stat.mode == "0770"
+        fail_msg: "/mnt/secrets is not a chasty2-owned 0770 directory"
+
+    - name: Assert /mnt/secrets is a mountpoint
+      ansible.builtin.command: mountpoint -q /mnt/secrets
+      changed_when: false

--- a/ansible/roles/dev/molecule/default/verify.yml
+++ b/ansible/roles/dev/molecule/default/verify.yml
@@ -1,6 +1,4 @@
 ---
-# Minimal smoke checks for the dev role. Idempotency is verified separately by
-# molecule's built-in `idempotence` step, not here.
 - name: Verify
   hosts: all
   become: true

--- a/ansible/roles/dev/tasks/dev_packages.yml
+++ b/ansible/roles/dev/tasks/dev_packages.yml
@@ -1,0 +1,33 @@
+---
+# Idempotent Claude Code install from Anthropic's signed apt repository
+- name: Package Config Block
+  become: true
+  tags: packages
+  block:
+    - name: Create apt keyrings directory
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Add Claude Code apt signing key
+      ansible.builtin.get_url:
+        url: "{{ dev_claude_key_url }}"
+        dest: "{{ dev_claude_keyring }}"
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Add Claude Code apt repository
+      ansible.builtin.apt_repository:
+        repo: "{{ dev_claude_repo }}"
+        filename: claude-code
+        state: present
+
+    - name: Install Claude Code
+      ansible.builtin.apt:
+        name: claude-code
+        state: present
+        update_cache: true

--- a/ansible/roles/dev/tasks/dev_services.yml
+++ b/ansible/roles/dev/tasks/dev_services.yml
@@ -1,8 +1,5 @@
 ---
-# Mount the secrets share for the human admin user.
-# Access is restricted to chasty2 by the server-side export (0770 chasty2:chasty2
-# with root_squash) — the podman and ansible service users fall under "other" and
-# are denied. The local mode below is cosmetic; NFS overlays it once mounted.
+# The local mode below is cosmetic; NFS overlays it once mounted.
 - name: Service Config Block
   become: true
   tags: services

--- a/ansible/roles/dev/tasks/dev_services.yml
+++ b/ansible/roles/dev/tasks/dev_services.yml
@@ -1,0 +1,24 @@
+---
+# Mount the secrets share for the human admin user.
+# Access is restricted to chasty2 by the server-side export (0770 chasty2:chasty2
+# with root_squash) — the podman and ansible service users fall under "other" and
+# are denied. The local mode below is cosmetic; NFS overlays it once mounted.
+- name: Service Config Block
+  become: true
+  tags: services
+  block:
+    - name: Create {{ dev_secrets_mount }}
+      ansible.builtin.file:
+        path: "{{ dev_secrets_mount }}"
+        state: directory
+        owner: "{{ dev_secrets_user }}"
+        group: "{{ dev_secrets_user }}"
+        mode: "0770"
+
+    - name: Mount secrets NFS volume
+      ansible.posix.mount:
+        src: "{{ dev_secrets_src }}"
+        path: "{{ dev_secrets_mount }}"
+        opts: rw,sync,hard
+        state: mounted
+        fstype: nfs

--- a/ansible/roles/dev/tasks/dev_services.yml
+++ b/ansible/roles/dev/tasks/dev_services.yml
@@ -17,7 +17,7 @@
 
     - name: Mount secrets NFS volume
       ansible.posix.mount:
-        src: "{{ dev_secrets_src }}"
+        src: 192.168.4.11:/ssd_mirror/secrets
         path: "{{ dev_secrets_mount }}"
         opts: rw,sync,hard
         state: mounted

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for dev role
+- name: Package Config
+  ansible.builtin.include_tasks: dev_packages.yml
+  tags: packages
+
+- name: Service Config
+  ansible.builtin.include_tasks: dev_services.yml
+  tags: services

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -1,0 +1,11 @@
+---
+# vars file for dev role
+# Claude Code is installed from Anthropic's signed apt repository. The stable
+# channel trails latest by ~a week and skips releases with major regressions.
+dev_claude_key_url: https://downloads.claude.ai/keys/claude-code.asc
+dev_claude_keyring: /etc/apt/keyrings/claude-code.asc
+dev_claude_repo: "deb [signed-by={{ dev_claude_keyring }}] https://downloads.claude.ai/claude-code/apt/stable stable main"
+
+dev_secrets_mount: /mnt/secrets
+dev_secrets_src: "{{ nfs_server }}:/ssd_mirror/secrets"
+dev_secrets_user: chasty2

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 # vars file for dev role
-# Claude Code is installed from Anthropic's signed apt repository. The stable
-# channel trails latest by ~a week and skips releases with major regressions.
+
 dev_claude_key_url: https://downloads.claude.ai/keys/claude-code.asc
 dev_claude_keyring: /etc/apt/keyrings/claude-code.asc
 dev_claude_repo: "deb [signed-by={{ dev_claude_keyring }}] https://downloads.claude.ai/claude-code/apt/stable stable main"

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -7,5 +7,4 @@ dev_claude_keyring: /etc/apt/keyrings/claude-code.asc
 dev_claude_repo: "deb [signed-by={{ dev_claude_keyring }}] https://downloads.claude.ai/claude-code/apt/stable stable main"
 
 dev_secrets_mount: /mnt/secrets
-dev_secrets_src: "{{ nfs_server }}:/ssd_mirror/secrets"
 dev_secrets_user: chasty2

--- a/ansible/virtual.yml
+++ b/ansible/virtual.yml
@@ -34,3 +34,8 @@
     - podman
     - jellyfin
     - foundry
+
+- name: Claude sandbox
+  hosts: lab
+  roles:
+    - dev

--- a/ansible/virtual.yml
+++ b/ansible/virtual.yml
@@ -15,27 +15,20 @@
     - public_ssh
 
 # As of now, all applications depend on podman role
-# - name: DNS & Database Server
-#   hosts: library
-#   roles:
-#     - podman
-#     - postgres
-#     - pihole
-
 - name: Web Proxy
   hosts: proxy
   roles:
     - podman
     - proxy
 
-- name: Web services
+- name: Web Services
   hosts: bailey
   roles:
     - podman
     - jellyfin
     - foundry
 
-- name: Claude sandbox
+- name: Development
   hosts: lab
   roles:
     - dev


### PR DESCRIPTION
## Summary

Completes the last two checklist items of #69: adds a `dev` Ansible role and attaches it to the `lab` VM.

- **Claude Code install** — installed system-wide from Anthropic's **signed apt repository** (idempotent via `get_url` + `apt_repository` + `apt`, non-interactive, no auto-update — updates flow through the normal system-upgrade path).
  - The native `install.sh` was rejected: it downloads fine but its `claude install` launcher step **busy-loops at 100% CPU forever** in a headless (no-TTY) Ansible context, which would hang CI and real provisioning alike.
- **Secrets mount** — `/mnt/secrets` mounts `192.168.4.11:/ssd_mirror/secrets` (esper's IP, matching the jellyfin pattern; the stage/lab VMs can't resolve the `esper` hostname). Access stays restricted to `chasty2` by the existing server-side export (`0770 chasty2:chasty2` + `root_squash`): the `podman` (uid 2004) and `ansible` (uid 1000) service users aren't in the `chasty2` group, so they fall under "other" (`---`) and are denied; even `become` root is squashed.
- **Wiring** — `dev` is attached to `lab` in `virtual.yml` (layers on top of the `common`/`virtual` roles it already receives).
- **Molecule scenario** — converges `common`+`dev` on the stage VM, verifies the `claude-code` package is installed and `/mnt/secrets` is a `chasty2`-owned mountpoint.

## Testing

- `./crowsnet.py test` — 38 unit tests pass
- `uv run ruff check` — pass
- `ansible-lint` (production profile) — pass
- `./crowsnet.py test --integration --role dev` — molecule provision → converge (apt install + secrets mount) → idempotency → verify → destroy passes

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)