### PR TITLE
fix: Set VM CPU type to host so AVX2-dependent binaries run

### DIFF
--- a/pulumi/components.py
+++ b/pulumi/components.py
@@ -38,6 +38,7 @@ class ProxmoxVM(pulumi.ComponentResource):
             cpu=proxmox.vm.VirtualMachineCpuArgs(
                 cores=cpu,
                 sockets=1,
+                type="host",
             ),
             memory=proxmox.vm.VirtualMachineMemoryArgs(
                 dedicated=ram,

--- a/tests/pulumi/test_components.py
+++ b/tests/pulumi/test_components.py
@@ -72,6 +72,7 @@ def test_scalar_inputs_propagate():
     def check(args):
         cpu, memory, vm_id, networks = args
         assert cpu["cores"] == 4
+        assert cpu["type"] == "host"
         assert memory["dedicated"] == 8192
         assert vm_id == 126
         assert networks[0]["mac_address"] == "BC:24:11:91:7B:19"


### PR DESCRIPTION
## Problem

Running `claude` on the newly built dev VM (`lab`) hung with a completely blank
screen — even `claude --version` never returned.

## Root cause

Confirmed via on-box diagnostics:

- `/usr/bin/claude` is a **Bun-compiled native binary** (claude-code v2.1.187).
  Bun requires **AVX2** (or at minimum SSE4.2 for its baseline build).
- The VM's virtual CPU was `QEMU Virtual CPU version 2.5+` (Proxmox default
  **`kvm64`**), whose flags top out at `sse2`/`pni` — no `sse4_2`, no `avx2`.
- `strace` showed a clean startup followed by an endless `futex` spin with **zero
  network syscalls**: the Bun runtime can't initialize its JIT on the unsupported
  CPU and deadlocks silently instead of crashing.

Ruled out: network, auth, the interactive TUI, NFS, and missing `node`.

The shared `ProxmoxVM` component set no CPU `type`, so every VM inherited the
minimal `kvm64` default. This was latent for all VMs; `lab` was the first to run
a Bun/AVX2 binary.

## Change

- `pulumi/components.py`: add `type="host"` to `VirtualMachineCpuArgs` so VMs
  inherit the physical host (`esper`) CPU features, including AVX2. Single node
  (`node_name="esper"`), so there is no live-migration concern.
- `tests/pulumi/test_components.py`: assert `cpu["type"] == "host"`.

## Verification

- `./crowsnet.py test` → 38 passed; `ruff` clean.
- Rebuilt the `lab` VM with the new CPU type — `claude` now launches instead of
  hanging (confirmed by the maintainer).

Prod/stage pick up `type="host"` on their next deploy + power-cycle; no immediate
action required there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)