### PR TITLE
feat: Add Claude git skill and PR template

### DIFF
--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: git
+description: Git workflow conventions for this repo. Use when creating branches, writing commits, opening or merging pull requests, or doing any git/gh work.
+---
+
+# Git Workflow
+
+## Branches
+
+- Start each plan by creating a new branch; all work happens outside `main`
+- One goal per branch
+- Pushes to `main` are blocked by a pre-push hook; enable once per clone:
+  `git config core.hooksPath .githooks`
+- If the repo has no `.githooks/pre-push`, bootstrap it from this skill:
+  copy `hooks/pre-push` (bundled next to this file) into `.githooks/`,
+  `chmod +x` it, then run `git config core.hooksPath .githooks`
+
+## Commits
+
+- Commit early and often, after each meaningful change
+- One commit per file or group of similar files
+- Keep messages concise: the subject states *what* changed
+- Add a body only when the *why* isn't obvious (complex or surprising changes)
+- Commits get squashed on merge — the PR is the durable record, so don't
+  duplicate PR-level detail in commit messages
+- When applicable, run the integration testing workflow and have it pass
+  before committing
+
+## Pull Requests
+
+- Title uses a semantic tag: `feat:`, `fix:`, `refactor:`, `docs:`
+  (the PR title becomes the squash-commit subject on `main`, so write it
+  as a good commit subject)
+- Fill in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`); reference
+  related issues with `Closes #N`
+- After pushing, check CI: `gh run list --branch <branch>`
+- Check in with the user for approval before merging
+
+## Merging
+
+- Always squash-and-merge: `gh pr merge --squash`

--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -8,7 +8,6 @@ description: Git workflow conventions for this repo. Use when creating branches,
 ## Branches
 
 - Start each plan by creating a new branch; all work happens outside `main`
-- One goal per branch
 - Pushes to `main` are blocked by a pre-push hook; enable once per clone:
   `git config core.hooksPath .githooks`
 - If the repo has no `.githooks/pre-push`, bootstrap it from this skill:
@@ -17,22 +16,19 @@ description: Git workflow conventions for this repo. Use when creating branches,
 
 ## Commits
 
-- Commit early and often, after each meaningful change
-- One commit per file or group of similar files
+- Commit early and often as you work. Aim for small, focused commits that each do one thing
+- If a commit message needs a comma, it likely can be split into two or more commits
 - Keep messages concise: the subject states *what* changed
 - Add a body only when the *why* isn't obvious (complex or surprising changes)
 - Commits get squashed on merge — the PR is the durable record, so don't
   duplicate PR-level detail in commit messages
-- When applicable, run the integration testing workflow and have it pass
-  before committing
 
 ## Pull Requests
 
 - Title uses a semantic tag: `feat:`, `fix:`, `refactor:`, `docs:`
   (the PR title becomes the squash-commit subject on `main`, so write it
   as a good commit subject)
-- Fill in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`); reference
-  related issues with `Closes #N`
+- Fill in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
 - After pushing, check CI: `gh run list --branch <branch>`
 - Check in with the user for approval before merging
 

--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -8,6 +8,9 @@ description: Git workflow conventions for this repo. Use when creating branches,
 ## Branches
 
 - Start each plan by creating a new branch; all work happens outside `main`
+- Name branches `<tag>/<kebab-slug>`, where `<tag>` is one of the PR tags below
+  (`feat/dev-role`, `chore/share-claude-settings`); prefix the slug with an
+  issue number when the work closes one (`fix/73-update-apt-cache`)
 - Pushes to `main` are blocked by a pre-push hook; enable once per clone:
   `git config core.hooksPath .githooks`
 - If the repo has no `.githooks/pre-push`, bootstrap it from this skill:
@@ -16,8 +19,10 @@ description: Git workflow conventions for this repo. Use when creating branches,
 
 ## Commits
 
-- Commit early and often as you work. Aim for small, focused commits that each do one thing
-- If a commit message needs a comma, it likely can be split into two or more commits
+- Commit early and often as you work. One commit does one thing — keep each
+  focused on a single concern
+- A comma in the subject is often a smell that two changes are bundled; when it
+  is, split them into separate commits
 - Keep messages concise: the subject states *what* changed
 - Add a body only when the *why* isn't obvious (complex or surprising changes)
 - Commits get squashed on merge — the PR is the durable record, so don't
@@ -25,13 +30,16 @@ description: Git workflow conventions for this repo. Use when creating branches,
 
 ## Pull Requests
 
-- Title uses a semantic tag: `feat:`, `fix:`, `refactor:`, `docs:`
+- Title uses a semantic tag: `feat:`, `fix:`, `refactor:`, `docs:`, `ci:`,
+  `chore:` — the same tags used as branch prefixes above
   (the PR title becomes the squash-commit subject on `main`, so write it
   as a good commit subject)
-- Fill in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
+- Fill in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`): Summary,
+  Changes, Validation, References
 - After pushing, check CI: `gh run list --branch <branch>`
 - Check in with the user for approval before merging
 
 ## Merging
 
-- Always squash-and-merge: `gh pr merge --squash`
+- Only merge once CI is green (check with `gh run list --branch <branch>`)
+- Always squash-and-merge and delete the branch: `gh pr merge --squash --delete-branch`

--- a/.claude/skills/git/hooks/pre-push
+++ b/.claude/skills/git/hooks/pre-push
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Block pushes to main; Claude works on branches only.
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$remote_ref" = "refs/heads/main" ]; then
+    echo "pre-push: pushing to 'main' is blocked." >&2
+    exit 1
+  fi
+done
+exit 0

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,10 @@
 
 <!-- Bullet list of notable changes -->
 
-## Testing
+## Validation
 
 <!-- How this was verified (integration tests, manual checks, CI) -->
 
-Closes #
+## References
+
+<!-- Mention and/or close related issues, link(s) to docs when applicable -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What this PR does and why, in 1-3 sentences -->
+
+## Changes
+
+<!-- Bullet list of notable changes -->
+
+## Testing
+
+<!-- How this was verified (integration tests, manual checks, CI) -->
+
+Closes #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,16 +73,9 @@ crowsnet/
 
 ## Git Conventions
 
-- Unless told otherwise, start each plan with creating a new branch
-- All work should be done in a branch outside of main
-- Each goal should be accomplished in its own branch
-- Commit early and often, after each meaningful change
-- When applicable, run the integration testing workflow and have it pass before committing
-- After pushing a branch, check that its CI tests pass (e.g. `gh run list --branch <branch>`)
-- Pushes to `main` are blocked by a pre-push hook; enable it once per clone with
-  `git config core.hooksPath .githooks`
-- When done, check in with the user for approval
-- Submit a PR to merge into main with a semantic tag in the title (e.g., `feat:`, `fix:`, `refactor:`, `docs:`)
+- Follow the `git` skill (`.claude/skills/git/SKILL.md`) for all branch, commit, PR, and merge work
+- Unless told otherwise, start each plan by creating a new branch; never work on `main`
+- When done, check in with the user for approval before merging
 
 
 ## Before You Start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,15 +71,9 @@ crowsnet/
 7. **Use uv for Python** - Invoke all Python tooling through `uv` (e.g. `uv run pytest`, `uv run python ...`, `uv pip ...`); never bare `python`/`pip`/`pytest`
 
 
-## Git Conventions
-
-- Follow the `git` skill (`.claude/skills/git/SKILL.md`) for all branch, commit, PR, and merge work
-- Unless told otherwise, start each plan by creating a new branch; never work on `main`
-- When done, check in with the user for approval before merging
-
-
 ## Before You Start
 
 | File | When to Read |
 |------|--------------|
+| .claude/skills/git/SKILL.md | Before planning any code changes |
 | ansible/CLAUDE.md | Writing new Ansible and Ansible-related code |


### PR DESCRIPTION
## Summary

Adds a Claude Code skill encoding this repo's git conventions — concise commits, semantic branch/PR tags, and squash-and-merge as the default — so PRs stay clean despite squash-merging. Consolidates the CLAUDE.md Git Conventions section into the skill.

## Changes

- New `.claude/skills/git/SKILL.md` with branch, commit, PR, and merge conventions — including branch naming (`<tag>/<kebab-slug>`), the full semantic-tag set (`feat/fix/refactor/docs/ci/chore`), and a CI-green precondition on `--squash --delete-branch`
- Bundled `.claude/skills/git/hooks/pre-push` (copy of `.githooks/pre-push`) so the skill is reusable in other projects, with bootstrap instructions
- New `.github/PULL_REQUEST_TEMPLATE.md` (Summary / Changes / Validation / References)
- Trimmed CLAUDE.md Git Conventions to a pointer at the skill

## Validation

- Verified the skill loads in-session after creation (appears in available skills)
- `diff .claude/skills/git/hooks/pre-push .githooks/pre-push` — identical; bundled copy is executable
- Cross-checked the tag list and branch-naming rule against `gh pr list --state merged`; skill section names match the PR template headings exactly
- Docs-only change; CI (Pytest, Ruff, Ansible-lint) checked on this branch

## References

Closes #84