### PR TITLE
chore: Depend on ansible-core and install collections explicitly

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,3 @@
 [defaults]
-# Local ansible config. Note that the container will have a separate config
+# Local ansible config. The container config is at ansible/ansible.cfg
 home = .ansible

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+# Keep Galaxy collections inside the project (out of ~/.ansible) so local
+# tooling (ansible-lint) resolves the versions pinned in
+# ansible/roles/requirements.yml. The container installs its own copy at
+# build time (see docker/Dockerfile).
+collections_path = ansible/.ansible/collections

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,8 +1,3 @@
 [defaults]
-# Consolidate everything Ansible writes (collections, Galaxy tmp/cache) into a
-# project-local dir instead of ~/.ansible, so local tooling (ansible-lint)
-# resolves the versions pinned in ansible/roles/requirements.yml and nothing
-# lands in the home dir. The container installs its own copy at build time
-# (see docker/Dockerfile). $ANSIBLE_HOME/collections is the default collections
-# path, so no separate collections_path is needed.
+# Local ansible config. Note that the container will have a separate config
 home = .ansible

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,8 @@
 [defaults]
-# Keep Galaxy collections inside the project (out of ~/.ansible) so local
-# tooling (ansible-lint) resolves the versions pinned in
-# ansible/roles/requirements.yml. The container installs its own copy at
-# build time (see docker/Dockerfile).
-collections_path = ansible/.ansible/collections
+# Consolidate everything Ansible writes (collections, Galaxy tmp/cache) into a
+# project-local dir instead of ~/.ansible, so local tooling (ansible-lint)
+# resolves the versions pinned in ansible/roles/requirements.yml and nothing
+# lands in the home dir. The container installs its own copy at build time
+# (see docker/Dockerfile). $ANSIBLE_HOME/collections is the default collections
+# path, so no separate collections_path is needed.
+home = .ansible

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,8 +51,9 @@ ENV ANSIBLE_GATHERING=smart
 ENV ANSIBLE_RETRY_FILES_ENABLED=false
 ENV ANSIBLE_PYTHON_INTERPRETER=auto_silent
 
-# Upgrade podman collection (fix: nfs bind mount idempotency)
-RUN ansible-galaxy collection install --upgrade containers.podman
+# Install pinned Ansible collections (ansible-core ships none bundled)
+COPY --chown=ansible:ansible requirements.yml /app/requirements.yml
+RUN ansible-galaxy collection install -r /app/requirements.yml
 
 # Set entrypoint
 COPY --chown=ansible:ansible ./entrypoint.sh /entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ ENV ANSIBLE_GATHERING=smart
 ENV ANSIBLE_RETRY_FILES_ENABLED=false
 ENV ANSIBLE_PYTHON_INTERPRETER=auto_silent
 
-# Install pinned Ansible collections (ansible-core ships none bundled)
+# Install pinned Ansible collections
 COPY --chown=ansible:ansible requirements.yml /app/requirements.yml
 RUN ansible-galaxy collection install -r /app/requirements.yml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Self-hosted homelab, runs entirely out of infrastructure-as-code"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "ansible>=11.6.0",
+    "ansible-core>=2.18.6",
     "click>=8.1.0",
     "pulumi>=3.220.0",
     "pulumi-proxmoxve>=7.13.0",

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -78,13 +78,13 @@ def test_build_container_copies_and_cleans_up(mocker):
     rc = container.build_container()
 
     assert rc == 0
-    # pyproject.toml and uv.lock copied into the docker build context
-    assert copy.call_count == 2
+    # pyproject.toml, uv.lock, and requirements.yml copied into the build context
+    assert copy.call_count == 3
     # build runs from the docker dir
     assert recorder["cwd"] == container.DOCKER_DIR
     assert recorder["cmd"][:3] == ["podman", "build", "."]
-    # both copied files cleaned up afterward
-    assert unlink.call_count == 2
+    # all copied files cleaned up afterward
+    assert unlink.call_count == 3
 
 
 def test_build_container_cleans_up_on_failure(mocker):
@@ -100,4 +100,4 @@ def test_build_container_cleans_up_on_failure(mocker):
         pass
 
     # finally block still removes the copied files
-    assert unlink.call_count == 2
+    assert unlink.call_count == 3

--- a/utilities/container.py
+++ b/utilities/container.py
@@ -16,20 +16,24 @@ CONTAINER_NAME = "crowsnet"
 def build_container() -> int:
     """Build the crowsnet container with podman.
 
-    Copies pyproject.toml and uv.lock into the docker build context,
-    builds the container, then cleans up the copied files.
+    Copies pyproject.toml, uv.lock, and the Ansible collection requirements
+    into the docker build context, builds the container, then cleans up the
+    copied files.
 
     Returns:
         The return code from podman build.
     """
     pyproject_src = PROJECT_ROOT / "pyproject.toml"
     uvlock_src = PROJECT_ROOT / "uv.lock"
+    requirements_src = ANSIBLE_DIR / "roles" / "requirements.yml"
     pyproject_dst = DOCKER_DIR / "pyproject.toml"
     uvlock_dst = DOCKER_DIR / "uv.lock"
+    requirements_dst = DOCKER_DIR / "requirements.yml"
 
     try:
         shutil.copy2(pyproject_src, pyproject_dst)
         shutil.copy2(uvlock_src, uvlock_dst)
+        shutil.copy2(requirements_src, requirements_dst)
 
         cmd = ["podman", "build", ".", "-t", f"{CONTAINER_NAME}:latest"]
         result = subprocess.run(cmd, cwd=DOCKER_DIR, check=False)
@@ -37,6 +41,7 @@ def build_container() -> int:
     finally:
         pyproject_dst.unlink(missing_ok=True)
         uvlock_dst.unlink(missing_ok=True)
+        requirements_dst.unlink(missing_ok=True)
 
 
 def run_container(action: str, args: list[str] | None = None) -> int:

--- a/uv.lock
+++ b/uv.lock
@@ -7,18 +7,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "ansible"
-version = "11.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ansible-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/6f/b491cd89e0393810b67598098ccb6a204d6a9202c9733a541568f69f6dea/ansible-11.6.0.tar.gz", hash = "sha256:934a948caa3ec1a3eb277e7ab1638b808b074a6e0c46045794cde7b637e275d8", size = 44015165, upload-time = "2025-05-20T20:28:24.184Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/92/8aebdbdd4574d337e47ebb7171fdc83095b82c255f8362f96681b113b79d/ansible-11.6.0-py3-none-any.whl", hash = "sha256:5b9c19d6a1080011c14c821bc7e6f8fd5b2a392219cbf2ced9be05e6d447d8cd", size = 55488595, upload-time = "2025-05-20T20:28:17.672Z" },
-]
-
-[[package]]
 name = "ansible-compat"
 version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -55,7 +43,7 @@ name = "ansible-crowsnet"
 version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "ansible" },
+    { name = "ansible-core" },
     { name = "click" },
     { name = "pulumi" },
     { name = "pulumi-proxmoxve" },
@@ -72,7 +60,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ansible", specifier = ">=11.6.0" },
+    { name = "ansible-core", specifier = ">=2.18.6" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "pulumi", specifier = ">=3.220.0" },
     { name = "pulumi-proxmoxve", specifier = ">=7.13.0" },


### PR DESCRIPTION
## Summary

`ansible-lint` warned that `community.general` and `containers.podman` were each installed twice. The bundled `ansible` meta-package ships ~90 collections, duplicating the versions pinned in `ansible/roles/requirements.yml`. Switch to `ansible-core` and manage collections explicitly.

## Changes

- Depend on `ansible-core>=2.18.6` instead of the bundled `ansible>=11.6.0` meta-package
- Install all pinned collections from `requirements.yml` in the image (previously only `containers.podman` was upgraded, relying on the bundle for the rest)
- Stage `requirements.yml` into the docker build context in `build_container()`
- Add a project-root `ansible.cfg` pointing local tooling at a project-local collections path (out of `~/.ansible`); the container keeps its own copy at build time
- Update `test_container` copy/cleanup counts (2 → 3)

## Validation

- `uv run ansible-lint` → 0 failures, 0 warnings on 190 files (duplicate + load warnings gone)
- `uv run pytest tests/` → 38 passed
- Verified clean resolution after deleting `~/.ansible` entirely

## References

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
