### PR TITLE
docs: Push git skill toward smaller, single-reason commits

### DIFF
--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -19,14 +19,17 @@ description: Git workflow conventions for this repo. Use when creating branches,
 
 ## Commits
 
-- Commit early and often as you work. One commit does one thing — keep each
-  focused on a single concern
-- A comma in the subject is often a smell that two changes are bundled; when it
-  is, split them into separate commits
-- Keep messages concise: the subject states *what* changed
-- Add a body only when the *why* isn't obvious (complex or surprising changes)
-- Commits get squashed on merge — the PR is the durable record, so don't
-  duplicate PR-level detail in commit messages
+- Commit early and often, and default to splitting: a change spanning several
+  files or layers is usually several commits. Squash-on-merge (see Merging)
+  means intermediate commits needn't build or pass, so splitting is cheap —
+  "each commit should work alone" is no reason to bundle
+- Split by the *reason* for each change: a dependency bump, wiring it into the
+  image, and a config tweak are separate commits even when shipped together.
+  Tests ride with the code they cover
+- If the subject needs "and", a comma, or a list, it is likely more than one commit —
+  stage the pieces with `git add -p` and commit each separately
+- Subject states *what* changed; add a body only when the *why* isn't obvious
+- The PR is the durable record, so don't repeat PR-level detail in commits
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary

Sharpen the git skill's Commits guidance so it actually produces smaller, single-reason commits. The prior "one commit does one thing" was abstract enough to rationalize bundling an entire multi-file change into one commit.

## Changes

- Name the squash-on-merge rationale: intermediate commits needn't build or pass, so "each commit should work alone" is no reason to bundle
- Reframe the split boundary as the *reason* for each change, with tests riding alongside the code they cover
- Extend the "comma smell" to conjunctions/lists and point at `git add -p` as the concrete splitting technique

## Validation

Documentation-only change to `.claude/skills/git/SKILL.md`.

## References

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
