### PR TITLE
feat: Assign microk8s role to kube-1

### DIFF
--- a/ansible/virtual.yml
+++ b/ansible/virtual.yml
@@ -32,3 +32,8 @@
   hosts: lab
   roles:
     - dev
+
+- name: MicroK8s
+  hosts: kube-1
+  roles:
+    - microk8s


### PR DESCRIPTION
## Summary

Assigned microk8s role to VM kube-1, a step towards migration to microk8s

## Changes

- Assigned microk8s role to kube-1

## Validation

Manual use of 'microk8s kubectl' on kube-1. Molecule testing of microk8s will be done in a different PR as its own scenario 

## References

N/A