### PR TITLE
feat: Add git and kubectl to dev role

### DIFF
--- a/ansible/roles/dev/README.md
+++ b/ansible/roles/dev/README.md
@@ -1,8 +1,8 @@
 # Dev Role
 
-Sets up the development sandbox (`lab`): installs Claude Code and kubectl from their
-respective signed apt repositories, installs baseline dev packages (git), and mounts
-the shared secrets volume.
+Sets up the development sandbox (`lab`): installs the dev packages, including Claude
+Code and kubectl from their respective signed apt repositories, and mounts the shared
+secrets volume.
 
 ## Requirements
 - `common` role
@@ -11,7 +11,7 @@ the shared secrets volume.
 - Debian-family host
 
 ## Variables
-- `dev_packages` - Baseline apt packages to install (`git`)
+- `dev_packages` - Apt packages to install on the dev host
 - `dev_claude_key_url` - Anthropic apt signing key to fetch
 - `dev_claude_keyring` - Where that key is stored (`/etc/apt/keyrings/claude-code.asc`)
 - `dev_claude_repo` - The apt source line, signed by the keyring above

--- a/ansible/roles/dev/README.md
+++ b/ansible/roles/dev/README.md
@@ -1,7 +1,8 @@
 # Dev Role
 
-Sets up the development sandbox (`lab`): installs Claude Code from Anthropic's signed apt
-repository and mounts the shared secrets volume.
+Sets up the development sandbox (`lab`): installs Claude Code and kubectl from their
+respective signed apt repositories, installs baseline dev packages (git), and mounts
+the shared secrets volume.
 
 ## Requirements
 - `common` role
@@ -10,8 +11,12 @@ repository and mounts the shared secrets volume.
 - Debian-family host
 
 ## Variables
+- `dev_packages` - Baseline apt packages to install (`git`)
 - `dev_claude_key_url` - Anthropic apt signing key to fetch
 - `dev_claude_keyring` - Where that key is stored (`/etc/apt/keyrings/claude-code.asc`)
 - `dev_claude_repo` - The apt source line, signed by the keyring above
+- `dev_kubectl_key_url` - Kubernetes apt signing key to fetch (pinned to v1.32)
+- `dev_kubectl_keyring` - Where that key is stored (`/etc/apt/keyrings/kubernetes-apt-keyring.asc`)
+- `dev_kubectl_repo` - The kubectl apt source line, signed by the keyring above
 - `dev_secrets_mount` - Mount point for the secrets volume (`/mnt/secrets`)
 - `dev_secrets_user` - Owner of the mount point

--- a/ansible/roles/dev/molecule/default/verify.yml
+++ b/ansible/roles/dev/molecule/default/verify.yml
@@ -7,14 +7,20 @@
     - name: Gather package facts
       ansible.builtin.package_facts:
 
-    - name: Assert the claude-code package is installed
+    - name: Assert the expected apt packages are installed
       ansible.builtin.assert:
         that:
           - "'claude-code' in ansible_facts.packages"
-        fail_msg: "claude-code apt package is not installed"
+          - "'git' in ansible_facts.packages"
+          - "'kubectl' in ansible_facts.packages"
+        fail_msg: "an expected apt package (claude-code, git, kubectl) is not installed"
 
     - name: Locate the claude binary on PATH
       ansible.builtin.command: which claude
+      changed_when: false
+
+    - name: Locate the kubectl binary on PATH
+      ansible.builtin.command: which kubectl
       changed_when: false
 
     - name: Stat the secrets mountpoint

--- a/ansible/roles/dev/tasks/dev_packages.yml
+++ b/ansible/roles/dev/tasks/dev_packages.yml
@@ -12,6 +12,12 @@
         group: root
         mode: "0755"
 
+    - name: Install dev packages
+      ansible.builtin.apt:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ dev_packages }}"
+
     - name: Add Claude Code apt signing key
       ansible.builtin.get_url:
         url: "{{ dev_claude_key_url }}"
@@ -29,5 +35,25 @@
     - name: Install Claude Code
       ansible.builtin.apt:
         name: claude-code
+        state: present
+        update_cache: true
+
+    - name: Add Kubernetes apt signing key
+      ansible.builtin.get_url:
+        url: "{{ dev_kubectl_key_url }}"
+        dest: "{{ dev_kubectl_keyring }}"
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Add Kubernetes apt repository
+      ansible.builtin.apt_repository:
+        repo: "{{ dev_kubectl_repo }}"
+        filename: kubernetes
+        state: present
+
+    - name: Install kubectl
+      ansible.builtin.apt:
+        name: kubectl
         state: present
         update_cache: true

--- a/ansible/roles/dev/tasks/dev_packages.yml
+++ b/ansible/roles/dev/tasks/dev_packages.yml
@@ -1,5 +1,6 @@
 ---
-# Idempotent Claude Code install from Anthropic's signed apt repository
+# Adds the Claude Code and Kubernetes signed apt repositories, then installs
+# the dev packages (see dev_packages) from them in a single apt call.
 - name: Package Config Block
   become: true
   tags: packages
@@ -11,12 +12,6 @@
         owner: root
         group: root
         mode: "0755"
-
-    - name: Install dev packages
-      ansible.builtin.apt:
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ dev_packages }}"
 
     - name: Add Claude Code apt signing key
       ansible.builtin.get_url:
@@ -32,12 +27,6 @@
         filename: claude-code
         state: present
 
-    - name: Install Claude Code
-      ansible.builtin.apt:
-        name: claude-code
-        state: present
-        update_cache: true
-
     - name: Add Kubernetes apt signing key
       ansible.builtin.get_url:
         url: "{{ dev_kubectl_key_url }}"
@@ -52,8 +41,8 @@
         filename: kubernetes
         state: present
 
-    - name: Install kubectl
+    - name: Install dev packages
       ansible.builtin.apt:
-        name: kubectl
+        name: "{{ dev_packages }}"
         state: present
         update_cache: true

--- a/ansible/roles/dev/tasks/dev_packages.yml
+++ b/ansible/roles/dev/tasks/dev_packages.yml
@@ -1,6 +1,4 @@
 ---
-# Adds the Claude Code and Kubernetes signed apt repositories, then installs
-# the dev packages (see dev_packages) from them in a single apt call.
 - name: Package Config Block
   become: true
   tags: packages

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -1,9 +1,16 @@
 ---
 # vars file for dev role
 
+dev_packages:
+  - git
+
 dev_claude_key_url: https://downloads.claude.ai/keys/claude-code.asc
 dev_claude_keyring: /etc/apt/keyrings/claude-code.asc
 dev_claude_repo: "deb [signed-by={{ dev_claude_keyring }}] https://downloads.claude.ai/claude-code/apt/stable stable main"
+
+dev_kubectl_key_url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
+dev_kubectl_keyring: /etc/apt/keyrings/kubernetes-apt-keyring.asc
+dev_kubectl_repo: "deb [signed-by={{ dev_kubectl_keyring }}] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /"
 
 dev_secrets_mount: /mnt/secrets
 dev_secrets_user: chasty2

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -3,6 +3,8 @@
 
 dev_packages:
   - git
+  - claude-code
+  - kubectl
 
 dev_claude_key_url: https://downloads.claude.ai/keys/claude-code.asc
 dev_claude_keyring: /etc/apt/keyrings/claude-code.asc

--- a/ansible/virtual.yml
+++ b/ansible/virtual.yml
@@ -31,6 +31,7 @@
 - name: Development
   hosts: lab
   roles:
+    - podman
     - dev
 
 - name: MicroK8s


### PR DESCRIPTION
## Summary

Extends the `dev` role (the `lab` sandbox VM) with the tooling chasty2 needs to
develop against the homelab's Kubernetes cluster: git, kubectl, and rootless
container support via the podman role.

## Changes

- Install `git` as a baseline dev package (new `dev_packages` var + apt loop).
- Install `kubectl` from the Kubernetes signed apt repo (`pkgs.k8s.io`, pinned to
  v1.32 to match the microk8s cluster channel), reusing the role's existing
  `claude-code` signed-apt-repo pattern.
- Assign the `podman` role to the `lab` play in `virtual.yml` alongside `dev`.
- Extend the dev molecule `verify.yml` to assert git + kubectl are installed and
  `kubectl` is on PATH; update the role README.

## Validation

- `./crowsnet.py test` — 38 host-side unit tests pass.
- `ansible-lint` on the dev role and `virtual.yml` — passes at the `production`
  profile.
- Integration: `./crowsnet.py test --integration --role dev` will converge the
  role on the stage VM and run the extended verifier.

## References

Closes #109
