### PR TITLE
feat: Copy microk8s kubeconfig to development servers

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -2,6 +2,10 @@ nfs_server: esper
 proxy_server: proxy
 backup_server: simic
 
+development_servers:
+  - abzan
+  - lab
+
 
 admin_users:
   - { name: "chasty2", uid: "1001", gid: "1001" }

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,11 +1,9 @@
 nfs_server: esper
 proxy_server: proxy
 backup_server: simic
-
 development_servers:
   - abzan
   - lab
-
 
 admin_users:
   - { name: "chasty2", uid: "1001", gid: "1001" }

--- a/ansible/roles/common/vars/main.yml
+++ b/ansible/roles/common/vars/main.yml
@@ -19,6 +19,7 @@ common_ssh_keys:
   - { name: "ansible", public_ssh_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGj0KFGQuRcbeX+P9z/O+nYDSu7NRSCx0BMDg5TwF5QJ CrowsNet ansible user" }
 
 common_packages:
+  - acl
   - sudo
   - vim
   - nmap

--- a/ansible/roles/microk8s/README.md
+++ b/ansible/roles/microk8s/README.md
@@ -15,3 +15,7 @@ cluster access, and distributes the node's kubeconfig to development servers so
 - `microk8s_users` - Users added to the `microk8s` group and given a `~/.kube` directory
 - `microk8s_kubeconfig_user` - User whose `~/.kube/config` receives the kubeconfig on development servers
 - `development_servers` - Inventory hosts that receive the kubeconfig (defined in `group_vars/all`)
+- `microk8s_permitted_ports` - Ports opened on the `internal` firewalld zone (defaults to `16443/tcp`, the kube-apiserver)
+
+The role opens the kube-apiserver port (`16443/tcp`) on the internal zone so
+`kubectl` from the development servers reaches the cluster with firewalld on.

--- a/ansible/roles/microk8s/README.md
+++ b/ansible/roles/microk8s/README.md
@@ -15,9 +15,3 @@ cluster access, and distributes the node's kubeconfig to development servers so
 - `microk8s_users` - Users added to the `microk8s` group and given a `~/.kube` directory
 - `microk8s_kubeconfig_user` - User whose `~/.kube/config` receives the kubeconfig on development servers
 - `development_servers` - Inventory hosts that receive the kubeconfig (defined in `group_vars/all`)
-
-After copying the kubeconfig, the role verifies `kubectl get nodes` works as
-`microk8s_kubeconfig_user` on each development server.
-
-Inspired by
-<https://github.com/8grams/ansible-microk8s/blob/main/install_microk8s.yaml>.

--- a/ansible/roles/microk8s/README.md
+++ b/ansible/roles/microk8s/README.md
@@ -1,16 +1,23 @@
 # MicroK8s Role
 
-Installs [MicroK8s](https://microk8s.io/) on `kube-1` and grants the configured users
-cluster access.
+Installs [MicroK8s](https://microk8s.io/) on `kube-1`, grants the configured users
+cluster access, and distributes the node's kubeconfig to development servers so
+`kubectl` reaches the cluster remotely.
 
 ## Requirements
 - `common` role
 - `community.general` collection
 - Ubuntu host with `snapd` available
+- `kubectl` available for `microk8s_kubeconfig_user` on each development server
 
 ## Variables
 - `microk8s_packages` - Snaps to install (`microk8s`, classic confinement, channel `1.32`)
 - `microk8s_users` - Users added to the `microk8s` group and given a `~/.kube` directory
+- `microk8s_kubeconfig_user` - User whose `~/.kube/config` receives the kubeconfig on development servers
+- `development_servers` - Inventory hosts that receive the kubeconfig (defined in `group_vars/all`)
+
+After copying the kubeconfig, the role verifies `kubectl get nodes` works as
+`microk8s_kubeconfig_user` on each development server.
 
 Inspired by
 <https://github.com/8grams/ansible-microk8s/blob/main/install_microk8s.yaml>.

--- a/ansible/roles/microk8s/README.md
+++ b/ansible/roles/microk8s/README.md
@@ -15,6 +15,3 @@ cluster access, and distributes the node's kubeconfig to development servers so
 - `microk8s_user` - User added to the `microk8s` group, given a `~/.kube` directory, and whose `~/.kube/config` receives the kubeconfig on development servers
 - `development_servers` - Inventory hosts that receive the kubeconfig (defined in `group_vars/all`)
 - `microk8s_permitted_ports` - Ports opened on the `internal` firewalld zone (defaults to `16443/tcp`, the kube-apiserver)
-
-The role opens the kube-apiserver port (`16443/tcp`) on the internal zone so
-`kubectl` from the development servers reaches the cluster with firewalld on.

--- a/ansible/roles/microk8s/README.md
+++ b/ansible/roles/microk8s/README.md
@@ -8,12 +8,11 @@ cluster access, and distributes the node's kubeconfig to development servers so
 - `common` role
 - `community.general` collection
 - Ubuntu host with `snapd` available
-- `kubectl` available for `microk8s_kubeconfig_user` on each development server
+- `kubectl` available for `microk8s_user` on each development server
 
 ## Variables
 - `microk8s_packages` - Snaps to install (`microk8s`, classic confinement, channel `1.32`)
-- `microk8s_users` - Users added to the `microk8s` group and given a `~/.kube` directory
-- `microk8s_kubeconfig_user` - User whose `~/.kube/config` receives the kubeconfig on development servers
+- `microk8s_user` - User added to the `microk8s` group, given a `~/.kube` directory, and whose `~/.kube/config` receives the kubeconfig on development servers
 - `development_servers` - Inventory hosts that receive the kubeconfig (defined in `group_vars/all`)
 - `microk8s_permitted_ports` - Ports opened on the `internal` firewalld zone (defaults to `16443/tcp`, the kube-apiserver)
 

--- a/ansible/roles/microk8s/handlers/main.yml
+++ b/ansible/roles/microk8s/handlers/main.yml
@@ -1,2 +1,9 @@
 ---
 # handlers file for microk8s
+- name: Verify kubectl access on development servers
+  become: true
+  become_user: "{{ microk8s_kubeconfig_user }}"
+  ansible.builtin.command: kubectl get nodes
+  changed_when: false
+  delegate_to: "{{ item }}"
+  loop: "{{ development_servers }}"

--- a/ansible/roles/microk8s/handlers/main.yml
+++ b/ansible/roles/microk8s/handlers/main.yml
@@ -2,7 +2,7 @@
 # handlers file for microk8s
 - name: Verify kubectl access on development servers
   become: true
-  become_user: "{{ microk8s_kubeconfig_user }}"
+  become_user: "{{ microk8s_user }}"
   ansible.builtin.command: kubectl get nodes
   changed_when: false
   delegate_to: "{{ item }}"

--- a/ansible/roles/microk8s/tasks/main.yml
+++ b/ansible/roles/microk8s/tasks/main.yml
@@ -17,6 +17,6 @@
 #   ansible.builtin.include_tasks: services.yml
 #   tags: services
 
-# - name: Firewall Config
-#   ansible.builtin.include_tasks: firewalld.yml
-#   tags: firewall
+- name: Firewall Config
+  ansible.builtin.include_tasks: microk8s_firewalld.yml
+  tags: firewall

--- a/ansible/roles/microk8s/tasks/microk8s_firewalld.yml
+++ b/ansible/roles/microk8s/tasks/microk8s_firewalld.yml
@@ -1,0 +1,13 @@
+---
+- name: Firewall Config Block
+  become: true
+  tags: firewall
+  block:
+    - name: Open permitted ports on firewalld zone 'internal'
+      ansible.posix.firewalld:
+        zone: internal
+        port: "{{ item }}"
+        state: enabled
+        permanent: true
+        immediate: true
+      with_items: "{{ microk8s_permitted_ports }}"

--- a/ansible/roles/microk8s/tasks/microk8s_users.yml
+++ b/ansible/roles/microk8s/tasks/microk8s_users.yml
@@ -3,21 +3,19 @@
   become: true
   tags: users
   block:
-    - name: Add user(s) to microk8s group
+    - name: Add user to microk8s group
       ansible.builtin.user:
-        name: "{{ item }}"
+        name: "{{ microk8s_user }}"
         groups: microk8s
         append: true
-      with_items: "{{ microk8s_users }}"
 
-    - name: Configure access to .kube caching directory(s)
+    - name: Configure access to .kube caching directory
       ansible.builtin.file:
-        path: "/home/{{ item }}/.kube"
-        owner: "{{ item }}"
-        group: "{{ item }}"
+        path: "/home/{{ microk8s_user }}/.kube"
+        owner: "{{ microk8s_user }}"
+        group: "{{ microk8s_user }}"
         mode: "0644"
         state: directory
-      with_items: "{{ microk8s_users }}"
 
     - name: Generate kubeconfig for remote access
       ansible.builtin.command: microk8s config
@@ -26,9 +24,9 @@
 
     - name: Ensure .kube directory exists on development servers
       ansible.builtin.file:
-        path: "/home/{{ microk8s_kubeconfig_user }}/.kube"
-        owner: "{{ microk8s_kubeconfig_user }}"
-        group: "{{ microk8s_kubeconfig_user }}"
+        path: "/home/{{ microk8s_user }}/.kube"
+        owner: "{{ microk8s_user }}"
+        group: "{{ microk8s_user }}"
         mode: "0700"
         state: directory
       delegate_to: "{{ item }}"
@@ -37,9 +35,9 @@
     - name: Copy kubeconfig to development servers
       ansible.builtin.copy:
         content: "{{ microk8s_kubeconfig.stdout }}"
-        dest: "/home/{{ microk8s_kubeconfig_user }}/.kube/config"
-        owner: "{{ microk8s_kubeconfig_user }}"
-        group: "{{ microk8s_kubeconfig_user }}"
+        dest: "/home/{{ microk8s_user }}/.kube/config"
+        owner: "{{ microk8s_user }}"
+        group: "{{ microk8s_user }}"
         mode: "0600"
       delegate_to: "{{ item }}"
       loop: "{{ development_servers }}"

--- a/ansible/roles/microk8s/tasks/microk8s_users.yml
+++ b/ansible/roles/microk8s/tasks/microk8s_users.yml
@@ -18,3 +18,29 @@
         mode: "0644"
         state: directory
       with_items: "{{ microk8s_users }}"
+
+    - name: Generate kubeconfig for remote access
+      ansible.builtin.command: microk8s config
+      register: microk8s_kubeconfig
+      changed_when: false
+
+    - name: Ensure .kube directory exists on development servers
+      ansible.builtin.file:
+        path: "/home/{{ microk8s_kubeconfig_user }}/.kube"
+        owner: "{{ microk8s_kubeconfig_user }}"
+        group: "{{ microk8s_kubeconfig_user }}"
+        mode: "0700"
+        state: directory
+      delegate_to: "{{ item }}"
+      loop: "{{ development_servers }}"
+
+    - name: Copy kubeconfig to development servers
+      ansible.builtin.copy:
+        content: "{{ microk8s_kubeconfig.stdout }}"
+        dest: "/home/{{ microk8s_kubeconfig_user }}/.kube/config"
+        owner: "{{ microk8s_kubeconfig_user }}"
+        group: "{{ microk8s_kubeconfig_user }}"
+        mode: "0600"
+      delegate_to: "{{ item }}"
+      loop: "{{ development_servers }}"
+      notify: Verify kubectl access on development servers

--- a/ansible/roles/microk8s/vars/main.yml
+++ b/ansible/roles/microk8s/vars/main.yml
@@ -3,10 +3,7 @@
 microk8s_packages:
   - microk8s
 
-microk8s_users:
-  - chasty2
-
-microk8s_kubeconfig_user: chasty2
+microk8s_user: chasty2
 
 microk8s_permitted_ports:
   - 16443/tcp  # microk8s kube-apiserver

--- a/ansible/roles/microk8s/vars/main.yml
+++ b/ansible/roles/microk8s/vars/main.yml
@@ -7,3 +7,6 @@ microk8s_users:
   - chasty2
 
 microk8s_kubeconfig_user: chasty2
+
+microk8s_permitted_ports:
+  - 16443/tcp  # microk8s kube-apiserver

--- a/ansible/roles/microk8s/vars/main.yml
+++ b/ansible/roles/microk8s/vars/main.yml
@@ -5,3 +5,5 @@ microk8s_packages:
 
 microk8s_users:
   - chasty2
+
+microk8s_kubeconfig_user: chasty2


### PR DESCRIPTION
## Summary

Makes microk8s reachable via `kubectl` from development machines by copying the `kube-1` node's kubeconfig into `chasty2`'s `~/.kube/config` on each development server, then verifying access works.

## Changes

- Add `development_servers` (`abzan`, `lab`) list to `group_vars/all`.
- Add `microk8s_kubeconfig_user` role var (`chasty2`).
- In the `microk8s` role, generate the kubeconfig on `kube-1` and `delegate_to` each development server to create `~/.kube` (0700) and write `~/.kube/config` (0600).
- Add a notified handler that runs `kubectl get nodes` as `chasty2` on each development server to verify access.
- Install `acl` via the `common` role so Ansible can become an unprivileged user (`chasty2`). Becoming a non-root user requires `setfacl` to hand off Ansible's temp files; without it the verify handler failed with `chmod: invalid mode: 'A+user:chasty2:rx:allow'`.
- Open the kube-apiserver port (`16443/tcp`) on `kube-1`'s internal firewalld zone. Without it, `kubectl` from the dev servers hit `dial tcp 192.168.4.126:16443: connect: no route to host` and only worked with firewalld off.
- Document the new behavior and variables in the role README.

## Validation

- `ansible-lint` passes (production profile) on the `common` and `microk8s` roles.
- Tasks are written to be idempotent (config generation is `changed_when: false`; the copy notifies the verify handler only on change).
- Manual: `./crowsnet.py configure`, then `kubectl get nodes` as `chasty2` succeeds on `abzan` and `lab` with firewalld left on.

## References

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
