### PR TITLE
feat: Install uv on dev role

### DIFF
--- a/ansible/roles/dev/README.md
+++ b/ansible/roles/dev/README.md
@@ -1,7 +1,8 @@
 # Dev Role
 
 Sets up the development sandbox (`lab`): installs the dev packages, including Claude
-Code and kubectl from their respective signed apt repositories, and mounts the shared
+Code and kubectl from their respective signed apt repositories, installs uv from
+Astral's install script (there is no apt repository for it), and mounts the shared
 secrets volume.
 
 ## Requirements
@@ -18,5 +19,8 @@ secrets volume.
 - `dev_kubectl_key_url` - Kubernetes apt signing key to fetch (pinned to v1.32)
 - `dev_kubectl_keyring` - Where that key is stored (`/etc/apt/keyrings/kubernetes-apt-keyring.asc`)
 - `dev_kubectl_repo` - The kubectl apt source line, signed by the keyring above
+- `dev_uv_installer_url` - Astral install script to fetch
+- `dev_uv_installer_path` - Where that script is stored (`/usr/local/src/uv-install.sh`)
+- `dev_uv_install_dir` - Where `uv` and `uvx` are installed (`/usr/local/bin`)
 - `dev_secrets_mount` - Mount point for the secrets volume (`/mnt/secrets`)
 - `dev_secrets_user` - Owner of the mount point

--- a/ansible/roles/dev/molecule/default/verify.yml
+++ b/ansible/roles/dev/molecule/default/verify.yml
@@ -23,6 +23,17 @@
       ansible.builtin.command: which kubectl
       changed_when: false
 
+    - name: Locate the uv binaries on PATH
+      ansible.builtin.command: "which {{ item }}"
+      changed_when: false
+      loop:
+        - uv
+        - uvx
+
+    - name: Run uv
+      ansible.builtin.command: uv --version
+      changed_when: false
+
     - name: Stat the secrets mountpoint
       ansible.builtin.stat:
         path: /mnt/secrets

--- a/ansible/roles/dev/tasks/dev_packages.yml
+++ b/ansible/roles/dev/tasks/dev_packages.yml
@@ -44,3 +44,19 @@
         name: "{{ dev_packages }}"
         state: present
         update_cache: true
+
+    - name: Download the uv installer
+      ansible.builtin.get_url:
+        url: "{{ dev_uv_installer_url }}"
+        dest: "{{ dev_uv_installer_path }}"
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Install uv
+      ansible.builtin.command: "{{ dev_uv_installer_path }}"
+      environment:
+        UV_INSTALL_DIR: "{{ dev_uv_install_dir }}"
+        UV_NO_MODIFY_PATH: "1"
+      args:
+        creates: "{{ dev_uv_install_dir }}/uv"

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -14,5 +14,9 @@ dev_kubectl_key_url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
 dev_kubectl_keyring: /etc/apt/keyrings/kubernetes-apt-keyring.asc
 dev_kubectl_repo: "deb [signed-by={{ dev_kubectl_keyring }}] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /"
 
+dev_uv_installer_url: https://astral.sh/uv/install.sh
+dev_uv_installer_path: /usr/local/src/uv-install.sh
+dev_uv_install_dir: /usr/local/bin
+
 dev_secrets_mount: /mnt/secrets
 dev_secrets_user: chasty2


### PR DESCRIPTION
## Summary

Installs `uv` (and `uvx`) system-wide on the development sandbox (`lab`). The host
already had `git`, `claude-code`, and `kubectl` but no Python package manager, so
agents working from `lab` could not run the uv-driven tooling this repo mandates.

## Changes

- Install uv from Astral's official install script into `/usr/local/bin`. Astral
  publishes no apt repository, so the role's signed-apt-repo pattern does not apply
- Fetch the installer with `get_url` (the module the role already uses for apt keys)
  rather than a `curl | sh` pipe — this also avoids adding `curl`, which is not in
  `common_packages`. The script itself falls back to `wget`, which `common` installs
- `UV_INSTALL_DIR=/usr/local/bin` selects the flat layout so the binaries land directly
  on `PATH`; `UV_NO_MODIFY_PATH=1` keeps the installer out of the shell profiles
- `creates:` guards the install task. The install receipt is left in place deliberately,
  so `uv self update` keeps working on the host
- Extend the Molecule verifier with `which uv` / `which uvx` and a `uv --version` run

## Validation

- `./crowsnet.py test` — 38 passed
- `uv run ansible-lint ansible/roles/dev` — 0 failures, 0 warnings (production profile)
- `./crowsnet.py test --integration --role dev` — converge `failed=0`, **idempotence
  `changed=0`** (proves the `creates:` guard holds), verifier `ok=9 failed=0`, stage VM
  destroyed cleanly

Note: an earlier run of the integration suite failed on the pre-existing
`Install dev packages` apt task because `unattended-upgrades` still held the dpkg lock
on the freshly-booted stage VM. That flake is unrelated to this change and cleared on
re-run, but it will keep recurring for every role until the shared
`molecule/shared/prepare.yml` waits the lock out.

## References

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)