### PR TITLE
fix: make fzf .bashrc entry human-readable

### DIFF
--- a/ansible/roles/common/tasks/users.yml
+++ b/ansible/roles/common/tasks/users.yml
@@ -56,9 +56,13 @@
       with_items: "{{ common_ssh_keys }}"
 
     - name: Enable fzf bash integration for admin users
-      ansible.builtin.lineinfile:
+      ansible.builtin.blockinfile:
         path: "/home/{{ item.name }}/.bashrc"
-        line: 'eval "$(fzf --bash)"'
+        marker: "# {mark} ANSIBLE MANAGED BLOCK - fzf"
+        block: |
+
+          # fzf: fuzzy-finder shell integration (completion + keybindings)
+          eval "$(fzf --bash)"
         owner: "{{ item.name }}"
         group: "{{ item.gid }}"
         create: false


### PR DESCRIPTION
## Summary

Switch the fzf bash-integration task from lineinfile to blockinfile so the inserted eval line is preceded by a blank line and an explanatory comment, instead of appearing as a bare unexplained line

## Changes

- Updated ~/.bashrc on admin_users group in common role with human-readable entry that enables fzf

## Validation

- Integration test passed
- Manual: 
    - [x] Removed 'eval' statement left from previous iteration in physical hosts
    - [ ] Rebuild VM's to clean up 

## References

Resolves #86 