### PR TITLE
feat: Install 'gh' in dev role

### DIFF
--- a/ansible/roles/dev/README.md
+++ b/ansible/roles/dev/README.md
@@ -1,7 +1,7 @@
 # Dev Role
 
 Sets up the development sandbox (`lab`): installs the dev packages, including Claude
-Code and kubectl from their respective signed apt repositories, installs uv from
+Code, kubectl, and gh from their respective signed apt repositories, installs uv from
 Astral's install script (there is no apt repository for it), and mounts the shared
 secrets volume.
 
@@ -16,8 +16,8 @@ secrets volume.
 - `dev_apt_repos` - List of signed apt repositories to add before installing
   `dev_packages`; each entry has `name` (apt source filename), `key_url` (signing
   key to fetch), `keyring` (where that key is stored under `/etc/apt/keyrings/`),
-  and `repo` (the apt source line, signed by the keyring). Covers Claude Code and
-  Kubernetes (kubectl, pinned to v1.32)
+  and `repo` (the apt source line, signed by the keyring). Covers Claude Code,
+  Kubernetes (kubectl, pinned to v1.32), and GitHub CLI (gh)
 - `dev_uv_installer_url` - Astral install script to fetch
 - `dev_uv_installer_path` - Where that script is stored (`/usr/local/src/uv-install.sh`)
 - `dev_uv_install_dir` - Where `uv` and `uvx` are installed (`/usr/local/bin`)

--- a/ansible/roles/dev/README.md
+++ b/ansible/roles/dev/README.md
@@ -13,12 +13,11 @@ secrets volume.
 
 ## Variables
 - `dev_packages` - Apt packages to install on the dev host
-- `dev_claude_key_url` - Anthropic apt signing key to fetch
-- `dev_claude_keyring` - Where that key is stored (`/etc/apt/keyrings/claude-code.asc`)
-- `dev_claude_repo` - The apt source line, signed by the keyring above
-- `dev_kubectl_key_url` - Kubernetes apt signing key to fetch (pinned to v1.32)
-- `dev_kubectl_keyring` - Where that key is stored (`/etc/apt/keyrings/kubernetes-apt-keyring.asc`)
-- `dev_kubectl_repo` - The kubectl apt source line, signed by the keyring above
+- `dev_apt_repos` - List of signed apt repositories to add before installing
+  `dev_packages`; each entry has `name` (apt source filename), `key_url` (signing
+  key to fetch), `keyring` (where that key is stored under `/etc/apt/keyrings/`),
+  and `repo` (the apt source line, signed by the keyring). Covers Claude Code and
+  Kubernetes (kubectl, pinned to v1.32)
 - `dev_uv_installer_url` - Astral install script to fetch
 - `dev_uv_installer_path` - Where that script is stored (`/usr/local/src/uv-install.sh`)
 - `dev_uv_install_dir` - Where `uv` and `uvx` are installed (`/usr/local/bin`)

--- a/ansible/roles/dev/README.md
+++ b/ansible/roles/dev/README.md
@@ -16,8 +16,7 @@ secrets volume.
 - `dev_apt_repos` - List of signed apt repositories to add before installing
   `dev_packages`; each entry has `name` (apt source filename), `key_url` (signing
   key to fetch), `keyring` (where that key is stored under `/etc/apt/keyrings/`),
-  and `repo` (the apt source line, signed by the keyring). Covers Claude Code,
-  Kubernetes (kubectl, pinned to v1.32), and GitHub CLI (gh)
+  and `repo` (the apt source line, signed by the keyring)
 - `dev_uv_installer_url` - Astral install script to fetch
 - `dev_uv_installer_path` - Where that script is stored (`/usr/local/src/uv-install.sh`)
 - `dev_uv_install_dir` - Where `uv` and `uvx` are installed (`/usr/local/bin`)

--- a/ansible/roles/dev/molecule/default/verify.yml
+++ b/ansible/roles/dev/molecule/default/verify.yml
@@ -13,7 +13,8 @@
           - "'claude-code' in ansible_facts.packages"
           - "'git' in ansible_facts.packages"
           - "'kubectl' in ansible_facts.packages"
-        fail_msg: "an expected apt package (claude-code, git, kubectl) is not installed"
+          - "'gh' in ansible_facts.packages"
+        fail_msg: "an expected apt package (claude-code, git, kubectl, gh) is not installed"
 
     - name: Locate the claude binary on PATH
       ansible.builtin.command: which claude
@@ -21,6 +22,10 @@
 
     - name: Locate the kubectl binary on PATH
       ansible.builtin.command: which kubectl
+      changed_when: false
+
+    - name: Locate the gh binary on PATH
+      ansible.builtin.command: which gh
       changed_when: false
 
     - name: Locate the uv binaries on PATH

--- a/ansible/roles/dev/molecule/default/verify.yml
+++ b/ansible/roles/dev/molecule/default/verify.yml
@@ -10,28 +10,21 @@
     - name: Assert the expected apt packages are installed
       ansible.builtin.assert:
         that:
-          - "'claude-code' in ansible_facts.packages"
-          - "'git' in ansible_facts.packages"
-          - "'kubectl' in ansible_facts.packages"
-          - "'gh' in ansible_facts.packages"
-        fail_msg: "an expected apt package (claude-code, git, kubectl, gh) is not installed"
+          - "item in ansible_facts.packages"
+        fail_msg: "expected apt package {{ item }} is not installed"
+      loop:
+        - claude-code
+        - git
+        - kubectl
+        - gh
 
-    - name: Locate the claude binary on PATH
-      ansible.builtin.command: which claude
-      changed_when: false
-
-    - name: Locate the kubectl binary on PATH
-      ansible.builtin.command: which kubectl
-      changed_when: false
-
-    - name: Locate the gh binary on PATH
-      ansible.builtin.command: which gh
-      changed_when: false
-
-    - name: Locate the uv binaries on PATH
+    - name: Locate expected binaries on PATH
       ansible.builtin.command: "which {{ item }}"
       changed_when: false
       loop:
+        - claude
+        - kubectl
+        - gh
         - uv
         - uvx
 

--- a/ansible/roles/dev/tasks/dev_packages.yml
+++ b/ansible/roles/dev/tasks/dev_packages.yml
@@ -11,33 +11,25 @@
         group: root
         mode: "0755"
 
-    - name: Add Claude Code apt signing key
+    - name: Add apt signing keys
       ansible.builtin.get_url:
-        url: "{{ dev_claude_key_url }}"
-        dest: "{{ dev_claude_keyring }}"
+        url: "{{ item.key_url }}"
+        dest: "{{ item.keyring }}"
         owner: root
         group: root
         mode: "0644"
+      loop: "{{ dev_apt_repos }}"
+      loop_control:
+        label: "{{ item.name }}"
 
-    - name: Add Claude Code apt repository
+    - name: Add apt repositories
       ansible.builtin.apt_repository:
-        repo: "{{ dev_claude_repo }}"
-        filename: claude-code
+        repo: "{{ item.repo }}"
+        filename: "{{ item.name }}"
         state: present
-
-    - name: Add Kubernetes apt signing key
-      ansible.builtin.get_url:
-        url: "{{ dev_kubectl_key_url }}"
-        dest: "{{ dev_kubectl_keyring }}"
-        owner: root
-        group: root
-        mode: "0644"
-
-    - name: Add Kubernetes apt repository
-      ansible.builtin.apt_repository:
-        repo: "{{ dev_kubectl_repo }}"
-        filename: kubernetes
-        state: present
+      loop: "{{ dev_apt_repos }}"
+      loop_control:
+        label: "{{ item.name }}"
 
     - name: Install dev packages
       ansible.builtin.apt:

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -6,13 +6,15 @@ dev_packages:
   - claude-code
   - kubectl
 
-dev_claude_key_url: https://downloads.claude.ai/keys/claude-code.asc
-dev_claude_keyring: /etc/apt/keyrings/claude-code.asc
-dev_claude_repo: "deb [signed-by={{ dev_claude_keyring }}] https://downloads.claude.ai/claude-code/apt/stable stable main"
-
-dev_kubectl_key_url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
-dev_kubectl_keyring: /etc/apt/keyrings/kubernetes-apt-keyring.asc
-dev_kubectl_repo: "deb [signed-by={{ dev_kubectl_keyring }}] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /"
+dev_apt_repos:
+  - name: claude-code
+    key_url: https://downloads.claude.ai/keys/claude-code.asc
+    keyring: /etc/apt/keyrings/claude-code.asc
+    repo: "deb [signed-by=/etc/apt/keyrings/claude-code.asc] https://downloads.claude.ai/claude-code/apt/stable stable main"
+  - name: kubernetes
+    key_url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
+    keyring: /etc/apt/keyrings/kubernetes-apt-keyring.asc
+    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /"
 
 dev_uv_installer_url: https://astral.sh/uv/install.sh
 dev_uv_installer_path: /usr/local/src/uv-install.sh

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -5,6 +5,7 @@ dev_packages:
   - git
   - claude-code
   - kubectl
+  - gh
 
 dev_apt_repos:
   - name: claude-code
@@ -15,6 +16,10 @@ dev_apt_repos:
     key_url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
     keyring: /etc/apt/keyrings/kubernetes-apt-keyring.asc
     repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /"
+  - name: github-cli
+    key_url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    keyring: /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    repo: "deb [signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
 
 dev_uv_installer_url: https://astral.sh/uv/install.sh
 dev_uv_installer_path: /usr/local/src/uv-install.sh


### PR DESCRIPTION
## Summary

Installs the GitHub CLI (`gh`) on the `lab` dev sandbox via its signed apt repository. This is needed to fully manage PR's on its own

## Changes

- Refactor: collapse the per-tool signing-key/apt-repo vars and tasks (Claude Code, kubectl) into a single `dev_apt_repos` list looped over once, so adding another signed repo doesn't require copy-pasting the block.
- Add `gh` via its own `dev_apt_repos` entry (cli.github.com signed repo) and to `dev_packages`.
- Update `dev` role README and Molecule `verify.yml` to document/assert `gh`.

## Validation

- `./crowsnet.py test --integration --role dev` — provisioned the `stage` VM, converged the role, ran idempotency + verify (asserts `claude-code`, `kubectl`, and `gh` are installed and on `PATH`), then destroyed the VM. Passed.

## References

N/A