### PR TITLE
feat: Implement dev role on abzan

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and heavy compute
 |------|------|------|
 | `esper` | Physical | Proxmox VE hypervisor; NFS server for container data; nightly backups to PBS |
 | `simic` | Physical | Proxmox Backup Server |
-| `abzan` | Physical | GPU/development server; Jupyter and Sunshine game streaming |
+| `abzan` | Physical | GPU/development server |
 | `gate` | VM | Public-facing SSH bastion |
 | `proxy` | VM | Nginx Proxy Manager; terminates HTTP/HTTPS for public services |
 | `bailey` | VM | Web services: Jellyfin and FoundryVTT |

--- a/ansible/physical.yml
+++ b/ansible/physical.yml
@@ -18,5 +18,6 @@
   hosts: abzan
   roles:
     - podman
-    - jupyter
-    - sunshine
+    # - jupyter
+    # - sunshine
+    - dev


### PR DESCRIPTION
## Summary

`abzan` is moving away from the Jupyter notebook server and Sunshine game-streaming stack toward being a general development host, so it now runs the same `dev` role as `lab`. Its IP also moves from `192.168.4.25` to `192.168.4.26`.

## Changes

- `ansible/physical.yml` — comment out the `jupyter` and `sunshine` roles on abzan and add `dev`. `podman` and the inherited `common` role are unchanged; the role trees stay on disk so they can be re-enabled by uncommenting.
- `README.md` — abzan's description no longer mentions Jupyter/Sunshine.
- Not in this PR: the IP change lives in `ansible/hosts`, which is git-ignored, so it was applied locally only. The matching DHCP reservation for `.26` is router-side and outside this repo.

## Validation

- `ansible-playbook --syntax-check -i ansible/hosts ansible/site.yml` — passes
- `ansible-lint ansible/physical.yml` — 0 failures, profile `production`
- `./crowsnet.py test` — 38 passed

A live `./crowsnet.py configure --limit abzan` is still pending the `.26` DHCP reservation.

## References

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)