### PR TITLE
feat: Install Docker on the dev role

### DIFF
--- a/ansible/roles/dev/README.md
+++ b/ansible/roles/dev/README.md
@@ -1,9 +1,11 @@
 # Dev Role
 
 Sets up the development sandbox (`lab`): installs the dev packages, including Claude
-Code, kubectl, and gh from their respective signed apt repositories, installs uv from
-Astral's install script (there is no apt repository for it), and mounts the shared
-secrets volume.
+Code, kubectl, gh, and Docker CE from their respective signed apt repositories,
+installs uv from Astral's install script (there is no apt repository for it), adds the
+admin users to the `docker` group, and mounts the shared secrets volume.
+
+Docker group membership only takes effect on the user's next login session.
 
 ## Requirements
 - `common` role
@@ -17,6 +19,12 @@ secrets volume.
   `dev_packages`; each entry has `name` (apt source filename), `key_url` (signing
   key to fetch), `keyring` (where that key is stored under `/etc/apt/keyrings/`),
   and `repo` (the apt source line, signed by the keyring)
+- `dev_docker_repo_url` - Base URL of Docker's apt repository, derived from
+  `ansible_distribution` (Docker publishes a separate repository per distro, and the
+  suite is the release codename, unlike the other three repositories)
+- `dev_docker_arch` - Architecture for Docker's apt source line, derived from
+  `ansible_architecture`
+- `dev_services` - Services to start and enable
 - `dev_uv_installer_url` - Astral install script to fetch
 - `dev_uv_installer_path` - Where that script is stored (`/usr/local/src/uv-install.sh`)
 - `dev_uv_install_dir` - Where `uv` and `uvx` are installed (`/usr/local/bin`)

--- a/ansible/roles/dev/molecule/default/verify.yml
+++ b/ansible/roles/dev/molecule/default/verify.yml
@@ -17,6 +17,11 @@
         - git
         - kubectl
         - gh
+        - docker-ce
+        - docker-ce-cli
+        - containerd.io
+        - docker-buildx-plugin
+        - docker-compose-plugin
 
     - name: Locate expected binaries on PATH
       ansible.builtin.command: "which {{ item }}"
@@ -27,10 +32,32 @@
         - gh
         - uv
         - uvx
+        - docker
 
     - name: Run uv
       ansible.builtin.command: uv --version
       changed_when: false
+
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert docker is running and enabled
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services["docker.service"].state == "running"
+          - ansible_facts.services["docker.service"].status == "enabled"
+        fail_msg: "docker.service is not running and enabled"
+
+    - name: Read the docker group
+      ansible.builtin.getent:
+        database: group
+        key: docker
+
+    - name: Assert chasty2 belongs to the docker group
+      ansible.builtin.assert:
+        that:
+          - "'chasty2' in ansible_facts.getent_group['docker'][2].split(',')"
+        fail_msg: "chasty2 is not a member of the docker group"
 
     - name: Stat the secrets mountpoint
       ansible.builtin.stat:

--- a/ansible/roles/dev/tasks/dev_services.yml
+++ b/ansible/roles/dev/tasks/dev_services.yml
@@ -1,9 +1,16 @@
 ---
-# The local mode below is cosmetic; NFS overlays it once mounted.
 - name: Service Config Block
   become: true
   tags: services
   block:
+    - name: Start/enable dev services
+      ansible.builtin.service:
+        name: "{{ item }}"
+        state: started
+        enabled: true
+      with_items: "{{ dev_services }}"
+
+    # The local mode below is cosmetic; NFS overlays it once mounted.
     - name: Create {{ dev_secrets_mount }}
       ansible.builtin.file:
         path: "{{ dev_secrets_mount }}"

--- a/ansible/roles/dev/tasks/dev_users.yml
+++ b/ansible/roles/dev/tasks/dev_users.yml
@@ -1,0 +1,19 @@
+---
+# The docker package creates this group itself; declaring it keeps the `users`
+# tag runnable on its own.
+- name: User Config Block
+  become: true
+  tags: users
+  block:
+    - name: Add docker group
+      ansible.builtin.group:
+        name: docker
+        state: present
+
+    - name: Add admin users to the docker group
+      ansible.builtin.user:
+        name: "{{ item.name }}"
+        groups: docker
+        append: true
+        state: present
+      with_items: "{{ admin_users }}"

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -4,6 +4,10 @@
   ansible.builtin.include_tasks: dev_packages.yml
   tags: packages
 
+- name: User Config
+  ansible.builtin.include_tasks: dev_users.yml
+  tags: users
+
 - name: Service Config
   ansible.builtin.include_tasks: dev_services.yml
   tags: services

--- a/ansible/roles/dev/vars/main.yml
+++ b/ansible/roles/dev/vars/main.yml
@@ -6,6 +6,15 @@ dev_packages:
   - claude-code
   - kubectl
   - gh
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - docker-buildx-plugin
+  - docker-compose-plugin
+
+# Docker's apt repository is distro- and release-specific, unlike the others
+dev_docker_repo_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}"
+dev_docker_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}"
 
 dev_apt_repos:
   - name: claude-code
@@ -20,6 +29,13 @@ dev_apt_repos:
     key_url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
     keyring: /etc/apt/keyrings/githubcli-archive-keyring.gpg
     repo: "deb [signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+  - name: docker
+    key_url: "{{ dev_docker_repo_url }}/gpg"
+    keyring: /etc/apt/keyrings/docker.asc
+    repo: "deb [arch={{ dev_docker_arch }} signed-by=/etc/apt/keyrings/docker.asc] {{ dev_docker_repo_url }} {{ ansible_distribution_release }} stable"
+
+dev_services:
+  - docker
 
 dev_uv_installer_url: https://astral.sh/uv/install.sh
 dev_uv_installer_path: /usr/local/src/uv-install.sh


### PR DESCRIPTION
## Summary

Adds Docker CE to the `dev` role, so the development sandboxes (`lab` and `abzan`) have a container engine available. Docker is installed from its official signed apt repository, following the existing `dev_apt_repos` pattern.

## Changes

- **`vars/main.yml`** — adds the five Docker CE packages (`docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin`) and a fourth `dev_apt_repos` entry. Unlike the three existing repos, Docker publishes a separate repository per distro and keys the suite to the release codename, so `dev_docker_repo_url` / `dev_docker_arch` / `ansible_distribution_release` derive the source line from facts — the same approach already used in `roles/sunshine/vars/main.yml`. This matters because the role runs on both `lab` (VM clone) and `abzan` (separate physical install).
- **`tasks/dev_users.yml`** (new, tag `users`) — declares the `docker` group and appends `admin_users` to it, so `docker` works without `sudo`. Wired into `main.yml` after Package Config.
- **`tasks/dev_services.yml`** — starts and enables `docker` via a new `dev_services` list, mirroring `common_services`.
- **`molecule/default/verify.yml`** — asserts the five packages are installed, `docker` is on `PATH`, `docker.service` is running and enabled, and `chasty2` is in the `docker` group.
- **`README.md`** — documents the new variables and notes that group membership takes effect on next login.

Note: `docker` group membership is effectively root-equivalent on the host; this was a deliberate choice for a dev sandbox.

## Validation

- `./crowsnet.py test` — 38 passed.
- `uv run ansible-lint roles/dev` — 0 failures, 0 warnings on 10 files at the `production` profile.
- `./crowsnet.py test --integration --role dev` — full pass on the real `stage` VM:
  - converge `ok=39 changed=22 failed=0`
  - **idempotence `ok=37 changed=0`** (the templated repo line and `apt_repository` re-run clean)
  - verify `ok=11 failed=0` — all Docker assertions green
  - destroy clean
- Rendered source line on Ubuntu noble: `deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable`. Both `linux/ubuntu/dists/noble` and `linux/debian/dists/bookworm` return 200, so the fact-derived URL holds for either distro.

## References

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)