### PR TITLE
fix: Install curl in the common role

### DIFF
--- a/ansible/roles/common/vars/main.yml
+++ b/ansible/roles/common/vars/main.yml
@@ -24,6 +24,7 @@ common_packages:
   - vim
   - nmap
   - wget
+  - curl
   - firewalld
   - less
   - nfs-common

--- a/ansible/roles/dev/molecule/default/verify.yml
+++ b/ansible/roles/dev/molecule/default/verify.yml
@@ -28,6 +28,7 @@
       changed_when: false
       loop:
         - claude
+        - curl
         - kubectl
         - gh
         - uv


### PR DESCRIPTION
## Summary

`./crowsnet.py configure` failed on `abzan` at **TASK [dev : Install Pulumi]** because the Ubuntu 26 image ships without `curl`. Pulumi's install script from `get.pulumi.com` shells out to `curl` in nine places — the first at line 114, where it resolves the release to install — so the script aborted before downloading anything.

This is not a Pulumi bug or an Ubuntu 26 incompatibility; it's a missing baseline utility.

## Changes

- Add `curl` to `common_packages` (`ansible/roles/common/vars/main.yml`), next to the existing `wget`, so it is present on every host.
- Add `curl` to the "Locate expected binaries on PATH" loop in the dev role's molecule verifier, guarding the regression at the layer that depends on it.

No task-file changes were needed: `common` converges before `dev` (already declared in the dev role's Requirements), and the `Install Pulumi` task keeps its `creates:` guard, so it stays idempotent.

Why the neighbouring tasks didn't fail:

- "Download the Pulumi installer" uses `ansible.builtin.get_url` (Python `urllib`), not `curl`.
- "Install uv" succeeded because Astral's `install.sh` accepts *either* `curl` or `wget`, and `common` already installed `wget`. Pulumi's script hard-requires `curl`.

## Validation

- `./crowsnet.py test` — 38 passed.
- Not yet run against a host: `./crowsnet.py configure --limit abzan --tags packages` (expect `Install Pulumi` to report `changed`, then `ok` on a second run), and `./crowsnet.py test --integration --role dev` for the full converge → idempotence → verify cycle.

## References

Rejected alternatives: pinning `--version X.Y.Z` (as the error message suggests) does not help — it only skips the version lookup, and the script still uses `curl` to fetch the tarball. Replacing the script with `get_url` + `unarchive` would drop the dependency but breaks symmetry with the adjacent uv install for a one-package fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)