### PR TITLE
fix: Make the microk8s snap install idempotent

### DIFF
--- a/ansible/roles/microk8s/tasks/microk8s_packages.yml
+++ b/ansible/roles/microk8s/tasks/microk8s_packages.yml
@@ -7,5 +7,5 @@
       community.general.snap:
         name: "{{ item }}"
         classic: true
-        channel: 1.32
+        channel: "1.32/stable"
       with_items: "{{ microk8s_packages }}"

--- a/ansible/roles/microk8s/tasks/microk8s_users.yml
+++ b/ansible/roles/microk8s/tasks/microk8s_users.yml
@@ -17,6 +17,11 @@
         mode: "0700"
         state: directory
 
+    - name: Wait for microk8s to become ready
+      ansible.builtin.command: microk8s status --wait-ready --timeout 300
+      changed_when: false
+      check_mode: false
+
     - name: Generate kubeconfig for remote access
       ansible.builtin.command: microk8s config
       register: microk8s_kubeconfig

--- a/ansible/roles/microk8s/tasks/microk8s_users.yml
+++ b/ansible/roles/microk8s/tasks/microk8s_users.yml
@@ -21,6 +21,7 @@
       ansible.builtin.command: microk8s config
       register: microk8s_kubeconfig
       changed_when: false
+      check_mode: false
 
     - name: Ensure .kube directory exists on development servers
       ansible.builtin.file:

--- a/ansible/roles/microk8s/tasks/microk8s_users.yml
+++ b/ansible/roles/microk8s/tasks/microk8s_users.yml
@@ -14,7 +14,7 @@
         path: "/home/{{ microk8s_user }}/.kube"
         owner: "{{ microk8s_user }}"
         group: "{{ microk8s_user }}"
-        mode: "0644"
+        mode: "0700"
         state: directory
 
     - name: Generate kubeconfig for remote access


### PR DESCRIPTION
## Summary

Re-running the `microk8s` role always reported changes. `community.general.snap` compares the requested `channel` against the *Tracking* column of `snap list`, and snap expands a bare track to `<track>/stable` — so the role's `channel: 1.32` never matched the host's `1.32/stable`, and every run re-issued `snap refresh` and reported `changed`. Closes #116.

Three adjacent defects in the same role are fixed alongside it.

## Changes

- **`channel: 1.32` → `channel: "1.32/stable"`** — the #116 fix. The [module compares against the Tracking column](https://github.com/ansible-collections/community.general/blob/stable-10/plugins/modules/snap.py#L359) (`match[0] not in (channel, "latest/{0}".format(channel))`); the `latest/…` fallback only rescues bare risk levels like `stable`, never a versioned track. Quoting also stops the value parsing as a YAML float, where a future `1.30` would collapse to `1.3` and track the wrong release. The track stays at `1.32` — it is what `kube-1` already tracks, so this triggers no `snap refresh`.
- **`.kube` directory mode `0644` → `0700`** — a directory with no execute bit cannot be entered; `kube-1` had been sitting at `drw-r--r--`. Matches the `0700` the same path already gets on the development servers.
- **`check_mode: false` on *Generate kubeconfig*** — `command` has no check mode, so under `--check` the task was skipped, registered as `{"skipped": true}`, and the following `copy` died on the missing `.stdout`. Reading a kubeconfig changes nothing, so it is safe either way.
- **New *Wait for microk8s to become ready* gate** — the snap install returns as soon as the snap is unpacked, but the API server needs another 30–60s; on a first run `microk8s config` raced it and aborted the play.

## Validation

Run against the live `kube-1`:

- `configure --limit kube-1 --tags packages` twice → **`changed=0`**, with *Install microk8s* reporting `ok` on both runs (it was `changed` on every run before).
- `configure --limit kube-1 --tags firewall` twice → `changed=0`.
- `configure --limit kube-1 --tags users` → *Configure access to .kube caching directory* reported `changed` once as it corrected the mode drift, then `changed=0` on the re-run. Confirmed on the host: `drwx------`, and `sudo -u chasty2 ls ~/.kube` now succeeds.
- `configure --limit kube-1 --tags users --check` → *Wait for microk8s to become ready* and *Generate kubeconfig* both report `ok` instead of being skipped, so the check-mode crash is gone.
- Snap left untouched by the channel change: still `v1.32.13` rev `8702` on `1.32/stable`.
- `./crowsnet.py test` → 38 passed. `ansible-lint` on the role's tasks/handlers → 0 failures at the `production` profile.

**Caveat:** `abzan` (192.168.4.25) is currently unreachable, and the `users` tasks `delegate_to` every host in `development_servers`, so those runs end with `unreachable=1` for abzan. That is pre-existing and unrelated to this change — `lab` succeeds — but it means the `users` tag was not verified end-to-end across both development servers.

## References

Closes #116.

Follow-ups noted while investigating, not addressed here:
- microk8s is pinned to `1.32`, which has fallen out of the upstream patch window (newest track is `1.36/stable`) — filed separately.
- The role has no Molecule scenario and still carries the deprecated `tests/test.yml`, which targets `hosts: lab` although the role deploys to `kube-1`.
- The `delegate_to` + `loop` pattern aborts the whole play when one development server is down (exactly the abzan case above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
