### PR TITLE
feat: Add the kube-1 molecule scenario

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,9 @@
 ./crowsnet.py update                       # Update and reboot all VMs
 
 # Testing
-./crowsnet.py test                                # Unit tests (pytest, host-side, no infra)
-./crowsnet.py test --integration                  # Molecule integration suite (role: common)
-./crowsnet.py test --integration --role <role>    # Integration suite for a specific role
+./crowsnet.py test                                        # Unit tests (pytest, host-side, no infra)
+./crowsnet.py test --integration                          # Molecule integration suite (scenario: common)
+./crowsnet.py test --integration --scenario <scenario>    # Integration suite for a specific scenario
 ```
 
 ## Testing Workflow
@@ -40,11 +40,13 @@ The suite has two layers (a third, CI on a self-hosted runner, is still pending)
   dispatch, podman command construction, and Pulumi component logic. Lives in
   `tests/`. Run on every change via `./crowsnet.py test`.
 - **Integration (Molecule)** — provisions the real `stage` VM via Pulumi,
-  converges a role, checks idempotency, then tears the VM down (destroy always
-  runs last, even on failure). Run when changing an Ansible role via
-  `./crowsnet.py test --integration [--role <role>]`. Runs inside the ops
+  converges a scenario, checks idempotency, then tears the VM down (destroy always
+  runs last, even on failure). A scenario models a host and converges the role
+  stack that host receives; assertions live in each role's `tests/` directory.
+  Run when changing an Ansible role via
+  `./crowsnet.py test --integration [--scenario <scenario>]`. Runs inside the ops
   container and requires Pulumi `stage` access. See `ansible/CLAUDE.md` for how
-  to add a Molecule scenario to a role.
+  to add a Molecule scenario.
 
 ## Directory Structure
 ```

--- a/README.md
+++ b/README.md
@@ -104,12 +104,14 @@ The suite has two layers (a third, CI on a self-hosted runner, is still pending)
   podman command construction, and Pulumi component logic. Lives in [`tests/`](tests/)
 
 - **Integration (Molecule)** — provisions the real `stage` VM via Pulumi, converges a
-  role, checks idempotency, runs tests, then tears the VM down.
+  scenario, checks idempotency, runs tests, then tears the VM down. A scenario models a
+  host and applies the same role stack that host gets in production; the assertions it
+  runs live in each role's `tests/` directory
 
 ```bash
-./crowsnet.py test                                # unit tests
-./crowsnet.py test --integration                  # integration suite (role: common)
-./crowsnet.py test --integration --role <role>    # integration suite for a specific role
+./crowsnet.py test                                        # unit tests
+./crowsnet.py test --integration                          # integration suite (scenario: common)
+./crowsnet.py test --integration --scenario <scenario>    # integration suite for a specific scenario
 ```
 
 CI/CD is done via GitHub Actions

--- a/ansible/CLAUDE.md
+++ b/ansible/CLAUDE.md
@@ -33,8 +33,7 @@ role_name/
 │   ├── role_name_packages.yml      # Package management tasks
 │   ├── role_name_services.yml      # Service management tasks
 │   └── role_name_firewalld.yml     # Firewall configuration tasks
-├── molecule/
-│   └── default/          # Molecule integration scenario (see Molecule Testing)
+├── tests/                # Assertion tasks, one file per task file (see Molecule Testing)
 ├── vars/main.yml         # Role variables
 ├── handlers/main.yml     # Event handlers
 ├── templates/            # Jinja2 templates
@@ -43,37 +42,49 @@ role_name/
 
 This standardization allows predictable role structure and granular control over which aspects of configuration to apply during playbook runs.
 
-> **Note:** Roles are tested with Molecule (see below), not the legacy
-> `tests/test.yml` playbook. New roles get a `molecule/` scenario instead of a
-> `tests/` directory.
-
 ## Molecule Testing
 
-Roles are integration-tested with Molecule. A `molecule test` run provisions the
-real `stage` VM via Pulumi, converges the role, checks **idempotency**, runs
+Integration testing is done with Molecule. A `molecule test` run provisions the
+real `stage` VM via Pulumi, converges the scenario, checks **idempotency**, runs
 the verifier, then destroys the VM (destroy always runs last, even on failure).
 
-Run a role's scenario from the repo root:
+Run a scenario from the repo root:
 ```bash
-./crowsnet.py test --integration --role <role>   # defaults to `common`
+./crowsnet.py test --integration --scenario <scenario>   # defaults to `common`
 ```
 
-### Adding a scenario to a role
-Place the scenario under the role:
+### Scenarios are per host, tests are per role
+A scenario models a **host**, not a role. It converges the same role stack that
+host receives in `site.yml`, and its `verify.yml` does nothing but include the
+assertion tasks that each of those roles keeps in its own `tests/` directory.
+Roles are therefore reusable across scenarios, and a host is tested the way it is
+actually built:
+
 ```
-roles/<role>/molecule/default/
-├── molecule.yml      # scenario config
-├── converge.yml      # applies the role
-└── verify.yml        # smoke checks
+molecule/
+├── shared/           # create.yml, prepare.yml, destroy.yml — written once
+└── <host>/
+    ├── molecule.yml  # scenario config
+    ├── converge.yml  # applies the host's roles
+    └── verify.yml    # includes each role's tests/
+
+roles/<role>/tests/
+├── packages.yml      # assertions for <role>_packages.yml
+├── users.yml         # assertions for <role>_users.yml
+└── ...               # one file per task file, named to match
 ```
 
-The lifecycle playbooks (`create`, `prepare`, `destroy`) are written **once** in
-`ansible/molecule/shared/` and reused by every role — do **not** reimplement them
-per role. The fastest path to a new scenario is to copy
-`roles/common/molecule/default/` and adjust the role name.
+`ansible/molecule/kube-1/` is the reference scenario. The `common` and `dev`
+roles predate this layout and still carry role-scoped
+`roles/<role>/molecule/default/` scenarios; fold them in rather than adding more.
+
+The lifecycle playbooks (`create`, `prepare`, `destroy`) live **once** in
+`molecule/shared/` — do **not** reimplement them per scenario. Molecule runs from
+`ansible/`, so `MOLECULE_PROJECT_DIRECTORY` is that directory and every path is
+written relative to it.
 
 **`molecule.yml`** — `driver: default`; one platform named `stage`; a galaxy
-dependency pointing at `../requirements.yml`; `provisioner.playbooks` wiring the
+dependency pointing at the roles requirements; `provisioner.playbooks` wiring the
 three shared playbooks; `ANSIBLE_ROLES_PATH` set to the roles directory; and
 `verifier: ansible`:
 ```yaml
@@ -87,39 +98,60 @@ platforms:
 dependency:
   name: galaxy
   options:
-    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/../requirements.yml
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/roles/requirements.yml
 
 provisioner:
   name: ansible
   playbooks:
-    create: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/create.yml
-    prepare: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/prepare.yml
-    destroy: ${MOLECULE_PROJECT_DIRECTORY}/../../molecule/shared/destroy.yml
+    create: ${MOLECULE_PROJECT_DIRECTORY}/molecule/shared/create.yml
+    prepare: ${MOLECULE_PROJECT_DIRECTORY}/molecule/shared/prepare.yml
+    destroy: ${MOLECULE_PROJECT_DIRECTORY}/molecule/shared/destroy.yml
   env:
     ANSIBLE_HOST_KEY_CHECKING: "false"
-    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
 
 verifier:
   name: ansible
 ```
 
 **`converge.yml`** — `hosts: all`, `become: true`, loads shared vars from
-`group_vars/all`, and lists the role:
+`group_vars/all`, and lists the host's roles in `site.yml` order:
 ```yaml
 ---
 - name: Converge
   hosts: all
   become: true
   vars_files:
-    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/../../group_vars/all"
+    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/group_vars/all"
   roles:
+    - common # noqa syntax-check[specific]
     - <role> # noqa syntax-check[specific]
 ```
 
-**`verify.yml`** — smoke checks asserting the role's key
-effects (a service is running, a user exists, etc.). Every scenario must include
-one. Do **not** test idempotency here; molecule's built-in `idempotence` step
-handles that.
+**`verify.yml`** — includes only. Load each covered role's `vars/main.yml` through
+`vars_files` so the assertions read the same values the role applied; role vars are
+otherwise out of scope once the role finishes:
+```yaml
+---
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+  vars:
+    ansible_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
+  vars_files:
+    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/roles/<role>/vars/main.yml"
+  tasks:
+    - name: Verify <role> packages
+      ansible.builtin.include_tasks: "{{ ansible_dir }}/roles/<role>/tests/packages.yml"
+```
+
+Assertion tasks are read-only: give every `command` a `changed_when: false`. Do
+**not** test idempotency there; molecule's built-in `idempotence` step handles it.
+
+Roles must not reach outside the host they run on. A `delegate_to` at another
+inventory host makes a role unconvergeable against a single VM — put the work in
+the role that owns the target host instead.
 
 ## Formatting
 - End each `.yml` file with a newline

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,9 +1,7 @@
 nfs_server: esper
 proxy_server: proxy
 backup_server: simic
-development_servers:
-  - abzan
-  - lab
+microk8s_node: kube-1
 
 admin_users:
   - { name: "chasty2", uid: "1001", gid: "1001" }

--- a/ansible/molecule/kube-1/converge.yml
+++ b/ansible/molecule/kube-1/converge.yml
@@ -1,0 +1,12 @@
+---
+# The role stack kube-1 receives in site.yml: common and virtual from the
+# `virtual` play, then microk8s from its own.
+- name: Converge
+  hosts: all
+  become: true
+  vars_files:
+    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/group_vars/all"
+  roles:
+    - common # noqa syntax-check[specific]
+    - virtual # noqa syntax-check[specific]
+    - microk8s # noqa syntax-check[specific]

--- a/ansible/molecule/kube-1/molecule.yml
+++ b/ansible/molecule/kube-1/molecule.yml
@@ -1,0 +1,24 @@
+---
+driver:
+  name: default
+
+platforms:
+  - name: stage
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: ${MOLECULE_PROJECT_DIRECTORY}/roles/requirements.yml
+
+provisioner:
+  name: ansible
+  playbooks:
+    create: ${MOLECULE_PROJECT_DIRECTORY}/molecule/shared/create.yml
+    prepare: ${MOLECULE_PROJECT_DIRECTORY}/molecule/shared/prepare.yml
+    destroy: ${MOLECULE_PROJECT_DIRECTORY}/molecule/shared/destroy.yml
+  env:
+    ANSIBLE_HOST_KEY_CHECKING: "false"
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
+
+verifier:
+  name: ansible

--- a/ansible/molecule/kube-1/verify.yml
+++ b/ansible/molecule/kube-1/verify.yml
@@ -1,0 +1,24 @@
+---
+# Assertions live with the roles they cover, in roles/<role>/tests/. Each role's
+# vars are loaded so the assertions read the same values the role applied.
+# Idempotency is verified separately by molecule's built-in `idempotence` step.
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+  vars:
+    ansible_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
+  vars_files:
+    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/roles/microk8s/vars/main.yml"
+  tasks:
+    - name: Verify microk8s packages
+      ansible.builtin.include_tasks: "{{ ansible_dir }}/roles/microk8s/tests/packages.yml"
+
+    - name: Verify microk8s users
+      ansible.builtin.include_tasks: "{{ ansible_dir }}/roles/microk8s/tests/users.yml"
+
+    - name: Verify the microk8s cluster
+      ansible.builtin.include_tasks: "{{ ansible_dir }}/roles/microk8s/tests/cluster.yml"
+
+    - name: Verify microk8s firewalld
+      ansible.builtin.include_tasks: "{{ ansible_dir }}/roles/microk8s/tests/firewalld.yml"

--- a/ansible/roles/dev/README.md
+++ b/ansible/roles/dev/README.md
@@ -3,13 +3,20 @@
 Sets up the development sandbox (`lab`): installs the dev packages, including Claude
 Code, kubectl, gh, and Docker CE from their respective signed apt repositories,
 installs uv and Pulumi from their official install scripts (there is no apt repository for either), 
-adds the admin users to the `docker` group, and mounts the shared secrets volume.
+adds the admin users to the `docker` group, installs each admin user's kubeconfig so
+`kubectl` reaches the MicroK8s cluster, and mounts the shared secrets volume.
 
 Docker group membership only takes effect on the user's next login session.
+
+The kubeconfig is pulled from `microk8s_node` rather than pushed by the `microk8s`
+role. The tasks skip when that host is absent from the inventory or has no microk8s
+installed yet, so a from-scratch build picks the kubeconfig up on its second run.
 
 ## Requirements
 - `common` role
 - `ansible.posix` collection
+- `microk8s_node` reachable and running the `microk8s` role (optional; the kubeconfig
+  tasks skip without it)
 - NFS export `192.168.4.11:/ssd_mirror/secrets` served by the `proxmox` role
 - Debian-family host
 
@@ -24,6 +31,8 @@ Docker group membership only takes effect on the user's next login session.
   suite is the release codename, unlike the other three repositories)
 - `dev_docker_arch` - Architecture for Docker's apt source line, derived from
   `ansible_architecture`
+- `microk8s_node` - Inventory host whose kubeconfig is installed for the admin users
+  (defined in `group_vars/all`)
 - `dev_services` - Services to start and enable
 - `dev_uv_installer_url` - Astral install script to fetch
 - `dev_uv_installer_path` - Where that script is stored (`/usr/local/src/uv-install.sh`)

--- a/ansible/roles/dev/tasks/dev_users.yml
+++ b/ansible/roles/dev/tasks/dev_users.yml
@@ -17,3 +17,41 @@
         append: true
         state: present
       with_items: "{{ admin_users }}"
+
+    # The kubeconfig is only distributed once the node is up. Guarding on the
+    # binary keeps this a no-op on a first-ever run, where the dev plays are
+    # reached before the microk8s node is configured.
+    - name: Check whether the microk8s node is provisioned
+      ansible.builtin.stat:
+        path: /snap/bin/microk8s
+      register: dev_microk8s_binary
+      delegate_to: "{{ microk8s_node }}"
+      when: microk8s_node in groups['all']
+
+    - name: Generate kubeconfig from the microk8s node
+      ansible.builtin.command: microk8s config
+      register: dev_kubeconfig
+      changed_when: false
+      check_mode: false
+      delegate_to: "{{ microk8s_node }}"
+      when: dev_microk8s_binary.stat.exists | default(false)
+
+    - name: Configure access to .kube caching directory
+      ansible.builtin.file:
+        path: "/home/{{ item.name }}/.kube"
+        owner: "{{ item.name }}"
+        group: "{{ item.name }}"
+        mode: "0700"
+        state: directory
+      with_items: "{{ admin_users }}"
+      when: dev_microk8s_binary.stat.exists | default(false)
+
+    - name: Install kubeconfig for admin users
+      ansible.builtin.copy:
+        content: "{{ dev_kubeconfig.stdout }}"
+        dest: "/home/{{ item.name }}/.kube/config"
+        owner: "{{ item.name }}"
+        group: "{{ item.name }}"
+        mode: "0600"
+      with_items: "{{ admin_users }}"
+      when: dev_microk8s_binary.stat.exists | default(false)

--- a/ansible/roles/microk8s/README.md
+++ b/ansible/roles/microk8s/README.md
@@ -1,17 +1,20 @@
 # MicroK8s Role
 
-Installs [MicroK8s](https://microk8s.io/) on `kube-1`, grants the configured users
-cluster access, and distributes the node's kubeconfig to development servers so
-`kubectl` reaches the cluster remotely.
+Installs [MicroK8s](https://microk8s.io/) on `kube-1` and grants the configured user
+cluster access. Everything this role does is local to the node; the `dev` role is what
+pulls the node's kubeconfig onto the development servers.
 
 ## Requirements
 - `common` role
 - `community.general` collection
 - Ubuntu host with `snapd` available
-- `kubectl` available for `microk8s_user` on each development server
 
 ## Variables
 - `microk8s_packages` - Snaps to install (`microk8s`, classic confinement, channel `1.32`)
-- `microk8s_user` - User added to the `microk8s` group, given a `~/.kube` directory, and whose `~/.kube/config` receives the kubeconfig on development servers
-- `development_servers` - Inventory hosts that receive the kubeconfig (defined in `group_vars/all`)
-- `microk8s_permitted_ports` - Ports opened on the `internal` firewalld zone (defaults to `16443/tcp`, the kube-apiserver)
+- `microk8s_user` - User added to the `microk8s` group and given a `~/.kube` directory
+- `microk8s_permitted_ports` - Ports opened on the `internal` firewalld zone (the
+  kube-apiserver and the Kubernetes NodePort range)
+
+## Testing
+Covered by the `kube-1` Molecule scenario (`ansible/molecule/kube-1/`), whose
+`verify.yml` includes the assertion tasks in this role's `tests/` directory.

--- a/ansible/roles/microk8s/handlers/main.yml
+++ b/ansible/roles/microk8s/handlers/main.yml
@@ -1,9 +1,0 @@
----
-# handlers file for microk8s
-- name: Verify kubectl access on development servers
-  become: true
-  become_user: "{{ microk8s_user }}"
-  ansible.builtin.command: kubectl get nodes
-  changed_when: false
-  delegate_to: "{{ item }}"
-  loop: "{{ development_servers }}"

--- a/ansible/roles/microk8s/tasks/microk8s_users.yml
+++ b/ansible/roles/microk8s/tasks/microk8s_users.yml
@@ -21,30 +21,3 @@
       ansible.builtin.command: microk8s status --wait-ready --timeout 300
       changed_when: false
       check_mode: false
-
-    - name: Generate kubeconfig for remote access
-      ansible.builtin.command: microk8s config
-      register: microk8s_kubeconfig
-      changed_when: false
-      check_mode: false
-
-    - name: Ensure .kube directory exists on development servers
-      ansible.builtin.file:
-        path: "/home/{{ microk8s_user }}/.kube"
-        owner: "{{ microk8s_user }}"
-        group: "{{ microk8s_user }}"
-        mode: "0700"
-        state: directory
-      delegate_to: "{{ item }}"
-      loop: "{{ development_servers }}"
-
-    - name: Copy kubeconfig to development servers
-      ansible.builtin.copy:
-        content: "{{ microk8s_kubeconfig.stdout }}"
-        dest: "/home/{{ microk8s_user }}/.kube/config"
-        owner: "{{ microk8s_user }}"
-        group: "{{ microk8s_user }}"
-        mode: "0600"
-      delegate_to: "{{ item }}"
-      loop: "{{ development_servers }}"
-      notify: Verify kubectl access on development servers

--- a/ansible/roles/microk8s/tests/cluster.yml
+++ b/ansible/roles/microk8s/tests/cluster.yml
@@ -1,0 +1,27 @@
+---
+# Assertions that the node came up as a working single-node cluster
+- name: Wait for microk8s to report ready
+  ansible.builtin.command: microk8s status --wait-ready --timeout 300
+  register: microk8s_status
+  changed_when: false
+
+- name: Assert microk8s is running
+  ansible.builtin.assert:
+    that:
+      - "'microk8s is running' in microk8s_status.stdout"
+    fail_msg: "microk8s did not report itself as running"
+
+- name: Read the cluster nodes
+  ansible.builtin.command: microk8s kubectl get nodes -o json
+  register: microk8s_nodes
+  changed_when: false
+
+- name: Assert the node reports a Ready condition
+  ansible.builtin.assert:
+    that:
+      - microk8s_node_conditions | selectattr('type', 'eq', 'Ready')
+        | selectattr('status', 'eq', 'True') | list | length == 1
+    fail_msg: "the microk8s node is not Ready"
+  vars:
+    microk8s_node_conditions: >-
+      {{ (microk8s_nodes.stdout | from_json)['items'][0].status.conditions }}

--- a/ansible/roles/microk8s/tests/firewalld.yml
+++ b/ansible/roles/microk8s/tests/firewalld.yml
@@ -1,0 +1,13 @@
+---
+# Assertions for microk8s_firewalld.yml
+- name: Read the ports open on firewalld zone 'internal'
+  ansible.builtin.command: firewall-cmd --zone=internal --list-ports
+  register: microk8s_open_ports
+  changed_when: false
+
+- name: Assert the permitted ports are open
+  ansible.builtin.assert:
+    that:
+      - "item in microk8s_open_ports.stdout.split()"
+    fail_msg: "{{ item }} is not open on firewalld zone 'internal'"
+  loop: "{{ microk8s_permitted_ports }}"

--- a/ansible/roles/microk8s/tests/packages.yml
+++ b/ansible/roles/microk8s/tests/packages.yml
@@ -1,0 +1,23 @@
+---
+# Assertions for microk8s_packages.yml
+- name: List installed snaps
+  ansible.builtin.command: snap list
+  register: microk8s_snap_list
+  changed_when: false
+
+- name: Assert the microk8s snap is installed
+  ansible.builtin.assert:
+    that:
+      - "'microk8s' in microk8s_snap_list.stdout"
+    fail_msg: "the microk8s snap is not installed"
+
+- name: Stat the microk8s binary
+  ansible.builtin.stat:
+    path: /snap/bin/microk8s
+  register: microk8s_binary
+
+- name: Assert the microk8s binary exists
+  ansible.builtin.assert:
+    that:
+      - microk8s_binary.stat.exists
+    fail_msg: "/snap/bin/microk8s is missing"

--- a/ansible/roles/microk8s/tests/test.yml
+++ b/ansible/roles/microk8s/tests/test.yml
@@ -1,6 +1,0 @@
----
-- name: Test microk8s role configuration
-  hosts: lab
-  roles:
-    - common # noqa syntax-check[specific]
-    - microk8s # noqa syntax-check[specific]

--- a/ansible/roles/microk8s/tests/users.yml
+++ b/ansible/roles/microk8s/tests/users.yml
@@ -1,0 +1,26 @@
+---
+# Assertions for microk8s_users.yml
+- name: Read the microk8s group
+  ansible.builtin.getent:
+    database: group
+    key: microk8s
+
+- name: Assert the microk8s user belongs to the microk8s group
+  ansible.builtin.assert:
+    that:
+      - "microk8s_user in ansible_facts.getent_group['microk8s'][2].split(',')"
+    fail_msg: "{{ microk8s_user }} is not a member of the microk8s group"
+
+- name: Stat the .kube caching directory
+  ansible.builtin.stat:
+    path: "/home/{{ microk8s_user }}/.kube"
+  register: microk8s_kube_dir
+
+- name: Assert the .kube caching directory is owned by the microk8s user with mode 0700
+  ansible.builtin.assert:
+    that:
+      - microk8s_kube_dir.stat.isdir
+      - microk8s_kube_dir.stat.pw_name == microk8s_user
+      - microk8s_kube_dir.stat.gr_name == microk8s_user
+      - microk8s_kube_dir.stat.mode == "0700"
+    fail_msg: "/home/{{ microk8s_user }}/.kube is not a {{ microk8s_user }}-owned 0700 directory"

--- a/crowsnet.py
+++ b/crowsnet.py
@@ -51,11 +51,11 @@ def update(limit):
 
 @cli.command()
 @click.option("--integration", is_flag=True, help="Run the molecule integration suite against the stage VM")
-@click.option("--role", default="common", help="Role to run the integration suite against")
-def test(integration, role):
+@click.option("--scenario", default="common", help="Molecule scenario to run the integration suite against")
+def test(integration, scenario):
     """Run the test suite (pytest unit tests by default)."""
     if integration:
-        sys.exit(run_integration(role))
+        sys.exit(run_integration(scenario))
     sys.exit(run_pytest())
 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,9 +35,17 @@ case "$ACTION" in
         pulumi refresh --yes --stack "$@"
         ;;
     test)
-        ROLE="${1:-common}"
-        cd "/etc/ansible/roles/${ROLE}"
-        molecule test
+        SCENARIO="${1:-common}"
+        # Scenarios live in ansible/molecule/<scenario>/. The common and dev roles
+        # still carry their own role-scoped scenarios; drop the fallback once they
+        # are folded into project-level scenarios.
+        if [ -d "/etc/ansible/molecule/${SCENARIO}" ]; then
+            cd /etc/ansible
+            molecule test -s "${SCENARIO}"
+        else
+            cd "/etc/ansible/roles/${SCENARIO}"
+            molecule test
+        fi
         ;;
     *)
         echo "Unknown action: $ACTION"

--- a/tests/test_crowsnet.py
+++ b/tests/test_crowsnet.py
@@ -86,12 +86,12 @@ def test_test_integration_flag_runs_integration(runner, mocker):
     run_pytest.assert_not_called()
 
 
-def test_test_integration_accepts_role(runner, mocker):
+def test_test_integration_accepts_scenario(runner, mocker):
     mocker.patch("crowsnet.run_pytest", return_value=0)
     run_integration = mocker.patch("crowsnet.run_integration", return_value=0)
-    result = runner.invoke(crowsnet.cli, ["test", "--integration", "--role", "jellyfin"])
+    result = runner.invoke(crowsnet.cli, ["test", "--integration", "--scenario", "kube-1"])
     assert result.exit_code == 0
-    run_integration.assert_called_once_with("jellyfin")
+    run_integration.assert_called_once_with("kube-1")
 
 
 def test_exit_code_propagates(runner, mocker):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -28,10 +28,10 @@ def test_run_integration_dispatches_test_action(mocker):
     run_container.assert_called_once_with("test", ["common"])
 
 
-def test_run_integration_forwards_role(mocker):
+def test_run_integration_forwards_scenario(mocker):
     run_container = mocker.patch.object(testing, "run_container", return_value=0)
-    testing.run_integration("jellyfin")
-    run_container.assert_called_once_with("test", ["jellyfin"])
+    testing.run_integration("kube-1")
+    run_container.assert_called_once_with("test", ["kube-1"])
 
 
 def test_run_integration_propagates_return_code(mocker):

--- a/utilities/testing.py
+++ b/utilities/testing.py
@@ -21,19 +21,19 @@ def run_pytest() -> int:
     return result.returncode
 
 
-def run_integration(role: str = "common") -> int:
-    """Run the molecule integration suite for a role inside the ops container.
+def run_integration(scenario: str = "common") -> int:
+    """Run a molecule scenario inside the ops container.
 
     Dispatches the container's `test` action through the same `run_container`
     path as production (configure/deploy), so molecule sees the production mount
     layout (ansible -> /etc/ansible, pulumi -> /pulumi) and user-namespace mapping.
-    Molecule then provisions the lab VM via Pulumi, converges the role, checks
-    idempotency, and destroys the VM.
+    Molecule then provisions the stage VM via Pulumi, converges the scenario's
+    roles, checks idempotency, and destroys the VM.
 
     Args:
-        role: The role whose molecule scenario to run.
+        scenario: The molecule scenario to run.
 
     Returns:
         The return code from the container.
     """
-    return run_container("test", [role])
+    return run_container("test", [scenario])


### PR DESCRIPTION
## Summary

Adds the first Molecule scenario for `kube-1`, and with it a new convention: a scenario
models a **host** rather than a role. It lives in `ansible/molecule/<host>/`, converges
the same role stack that host receives in `site.yml`, and its `verify.yml` does nothing
but include assertion tasks that each role keeps in its own `tests/` directory.

Getting there required unblocking the `microk8s` role, which distributed its kubeconfig
to other inventory hosts via `delegate_to` and so could never converge against a single
VM. That work now belongs to the `dev` role, which owns those hosts.

## Changes

- **`microk8s` role is now node-local.** Dropped the delegated kubeconfig tasks, the
  `Verify kubectl access on development servers` handler, and a duplicate `.kube`
  directory task.
- **`dev` role pulls the kubeconfig** from `microk8s_node` instead of having it pushed.
  A `stat` guard skips the tasks when that host is absent from the inventory or has no
  microk8s yet, so a from-scratch build picks it up on its second pass.
- **`development_servers` → `microk8s_node`** in `group_vars/all`; the old var had no
  remaining consumers.
- **New scenario `ansible/molecule/kube-1/`** converging `common` + `virtual` +
  `microk8s`, with assertions in `roles/microk8s/tests/{packages,users,cluster,firewalld}.yml`
  replacing that role's legacy `tests/test.yml` playbook.
- **Runner takes a scenario, not a role.** `--role` → `--scenario`; `entrypoint.sh` runs
  molecule from `/etc/ansible`, falling back to the role-scoped layout that `common` and
  `dev` still use until they are folded in.
- **Docs** in `ansible/CLAUDE.md`, `CLAUDE.md`, and `README.md` updated to the new model.

## Validation

- `./crowsnet.py test --integration --scenario kube-1` — passed end to end against the
  real `stage` VM: converge, `Idempotence completed successfully`, all 8 verifier
  assertions executed (snap present, group membership, `.kube` mode 0700, `microk8s is
  running`, node `Ready`, both firewalld ports open), VM destroyed.
- `./crowsnet.py test --integration --scenario dev` — regression on the fallback path;
  the kubeconfig tasks skip rather than fail when `kube-1` is out of inventory.
- `./crowsnet.py test --integration --scenario common` — regression on the fallback path.
- `uv run pytest` — 43 passed. `uv run ruff check` — clean.
- `ansible-lint` — 0 failures on 171 files, `production` profile. It classifies the new
  `roles/microk8s/tests/*.yml` as task files, so no config override was needed.

## References

Closes #121. Advances #110 ("Create molecule scenario for microk8s and check services").

Known follow-ups, not addressed here:
- `common` and `dev` still carry role-scoped scenarios; folding them into per-host
  scenarios removes the fallback branch in `entrypoint.sh`.
- `virtual.yml` runs the `Development` play before the `MicroK8s` play, so `lab` needs a
  second `configure` pass on a from-scratch build before its kubeconfig lands.
